### PR TITLE
Header and footer are only instantiated once

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -25,15 +25,19 @@ import {
 } from 'react-router-dom';
 import router from './routes';
 import withAnalytics from './utils/Analytics';
+import AppHeaderMain from './components/appheader.main';
+import AppFooterMain from './components/appfooter.main';
 
 // eslint-disable-next-line react/no-array-index-key
 const routeComponents = router.map(({ path, component }, key) => <Route exact path={path} component={component} key={key} />);
 
 const Root = () => (
   <div id="root_router_div">
+    <AppHeaderMain />
     <Switch>
       {routeComponents}
     </Switch>
+    <AppFooterMain />
   </div>
 );
 const App = withRouter(withAnalytics(Root));

--- a/src/containers/AboutUsPage.jsx
+++ b/src/containers/AboutUsPage.jsx
@@ -21,14 +21,11 @@
 
 import React from 'react';
 import intl from 'react-intl-universal';
-import AppHeaderMain from '../components/appheader.main';
-import AppFooterMain from '../components/appfooter.main';
 
 function AboutUsPage() {
   return (
     <div className="viewport ui-container static-ui-container" data-region="viewPortRegion" style={{ display: 'block' }}>
       <div>
-        <AppHeaderMain />
         <div className="app-main static-contant-container" data-region="appMain" style={{ display: 'block' }}>
           <div>
             <div className="static-container container">
@@ -51,7 +48,6 @@ function AboutUsPage() {
             </div>
           </div>
         </div>
-        <AppFooterMain />
       </div>
     </div>
   );

--- a/src/containers/CartPage.jsx
+++ b/src/containers/CartPage.jsx
@@ -23,8 +23,6 @@ import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import intl from 'react-intl-universal';
 import { login } from '../utils/AuthService';
-import AppHeaderMain from '../components/appheader.main';
-import AppFooterMain from '../components/appfooter.main';
 import CartMain from '../components/cart.main';
 import CheckoutSummaryList from '../components/checkout.summarylist';
 import cortexFetch from '../utils/Cortex';
@@ -154,7 +152,6 @@ class CartPage extends React.Component {
     const { history } = this.props;
     return (
       <div>
-        <AppHeaderMain />
         <div className="cart-container container">
           <div className="cart-container-inner">
             <div data-region="cartTitleRegion" className="cart-title-container" style={{ display: 'block' }}>
@@ -197,7 +194,6 @@ class CartPage extends React.Component {
             )}
           </div>
         </div>
-        <AppFooterMain />
       </div>
     );
   }

--- a/src/containers/CategoryPage.jsx
+++ b/src/containers/CategoryPage.jsx
@@ -20,17 +20,13 @@
  */
 
 import React from 'react';
-import AppHeaderMain from '../components/appheader.main';
 import CategoryItemsMain from '../components/categoryitems.main';
-import AppFooterMain from '../components/appfooter.main';
 
 function CategoryPage(props) {
   return (
     <div>
-      <AppHeaderMain />
       {/* eslint-disable-next-line react/destructuring-assignment,react/prop-types */}
       <CategoryItemsMain categoryUrl={decodeURIComponent(props.match.params.url)} />
-      <AppFooterMain />
     </div>
   );
 }

--- a/src/containers/CheckoutAuthPage.jsx
+++ b/src/containers/CheckoutAuthPage.jsx
@@ -23,8 +23,6 @@ import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import intl from 'react-intl-universal';
 import { login, loginRegistered } from '../utils/AuthService';
-import AppHeaderMain from '../components/appheader.main';
-import AppFooterMain from '../components/appfooter.main';
 import cortexFetch from '../utils/Cortex';
 
 const Config = require('Config');
@@ -128,7 +126,6 @@ class CheckoutAuthPage extends React.Component {
     const { failedLogin, badEmail } = this.state;
     return (
       <div>
-        <AppHeaderMain />
         <div className="app-main" data-region="appMain" style={{ display: 'block' }}>
           <div className="container">
             <h3>
@@ -221,7 +218,6 @@ class CheckoutAuthPage extends React.Component {
             </div>
           </div>
         </div>
-        <AppFooterMain />
       </div>
     );
   }

--- a/src/containers/CheckoutPage.jsx
+++ b/src/containers/CheckoutPage.jsx
@@ -23,8 +23,6 @@ import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import intl from 'react-intl-universal';
 import { login } from '../utils/AuthService';
-import AppHeaderMain from '../components/appheader.main';
-import AppFooterMain from '../components/appfooter.main';
 import CheckoutSummaryList from '../components/checkout.summarylist';
 import AddressContainer from '../components/address.container';
 import ShippingOptionContainer from '../components/shippingoption.container';
@@ -468,7 +466,6 @@ class CheckoutPage extends React.Component {
       const { messages } = orderData._order[0];
       return (
         <div>
-          <AppHeaderMain />
           <div className="app-main" data-region="appMain" style={{ display: 'block' }}>
             <div className="checkout-container container">
               <div className="checkout-container-inner">
@@ -510,13 +507,11 @@ class CheckoutPage extends React.Component {
               </div>
             </div>
           </div>
-          <AppFooterMain />
         </div>
       );
     }
     return (
       <div>
-        <AppHeaderMain />
         <div className="app-main" data-region="appMain" style={{ display: 'block' }}>
           <div className="checkout-container container">
             <div className="checkout-container-inner">
@@ -533,7 +528,6 @@ class CheckoutPage extends React.Component {
             </div>
           </div>
         </div>
-        <AppFooterMain />
       </div>
     );
   }

--- a/src/containers/EditAddressPage.jsx
+++ b/src/containers/EditAddressPage.jsx
@@ -20,15 +20,11 @@
  */
 
 import React from 'react';
-import AppHeaderMain from '../components/appheader.main';
-import AppFooterMain from '../components/appfooter.main';
 import AddressFormMain from '../components/addressform.main';
 
 const EditAddressPage = props => (
   <div>
-    <AppHeaderMain />
     <AddressFormMain {...props} />
-    <AppFooterMain />
   </div>
 );
 

--- a/src/containers/HomePage.jsx
+++ b/src/containers/HomePage.jsx
@@ -21,8 +21,6 @@
 
 import React from 'react';
 import intl from 'react-intl-universal';
-import AppHeaderMain from '../components/appheader.main';
-import AppFooterMain from '../components/appfooter.main';
 
 import homeEspotMain from '../images/site-images/homepage-banner.jpg';
 import homeEspot2 from '../images/site-images/brake-icon.jpg';
@@ -40,7 +38,6 @@ function HomePage() {
   return (
     <div className="viewport ui-container home-ui-container" data-region="viewPortRegion" style={{ display: 'block' }}>
       <div>
-        <AppHeaderMain />
         <div className="home-contant-container" style={{ display: 'block' }}>
           <div>
             <div data-region="homeMainContentRegion" className="home-espot-container container" style={{ display: 'block' }}>
@@ -101,7 +98,6 @@ function HomePage() {
             </div>
           </div>
         </div>
-        <AppFooterMain />
       </div>
     </div>
   );

--- a/src/containers/MaintenancePage.jsx
+++ b/src/containers/MaintenancePage.jsx
@@ -22,8 +22,6 @@
 import React from 'react';
 import intl from 'react-intl-universal';
 import { Link } from 'react-router-dom';
-import AppHeaderMain from '../components/appheader.main';
-import AppFooterMain from '../components/appfooter.main';
 
 import doge from '../images/site-images/HikingDog.png';
 
@@ -35,7 +33,6 @@ function AboutUsPage() {
   return (
     <div className="viewport ui-container static-ui-container" data-region="viewPortRegion" style={{ display: 'block' }}>
       <div>
-        <AppHeaderMain hideHeaderNavigation />
         <div className="app-main static-contant-container" data-region="appMain" style={{ display: 'block' }}>
           <div>
             <div className="static-container container">
@@ -69,7 +66,6 @@ function AboutUsPage() {
             </div>
           </div>
         </div>
-        <AppFooterMain />
       </div>
     </div>
   );

--- a/src/containers/NewAddressPage.jsx
+++ b/src/containers/NewAddressPage.jsx
@@ -20,15 +20,11 @@
  */
 
 import React from 'react';
-import AppHeaderMain from '../components/appheader.main';
-import AppFooterMain from '../components/appfooter.main';
 import AddressFormMain from '../components/addressform.main';
 
 const NewAddressPage = props => (
   <div>
-    <AppHeaderMain />
     <AddressFormMain {...props} />
-    <AppFooterMain />
   </div>
 );
 

--- a/src/containers/NewPaymentPage.jsx
+++ b/src/containers/NewPaymentPage.jsx
@@ -20,15 +20,11 @@
  */
 
 import React from 'react';
-import AppHeaderMain from '../components/appheader.main';
-import AppFooterMain from '../components/appfooter.main';
 import PaymentFormMain from '../components/paymentform.main';
 
 const NewPaymentPage = props => (
   <div>
-    <AppHeaderMain />
     <PaymentFormMain {...props} />
-    <AppFooterMain />
   </div>
 );
 

--- a/src/containers/OrderHistoryPage.jsx
+++ b/src/containers/OrderHistoryPage.jsx
@@ -23,8 +23,6 @@ import React from 'react';
 import intl from 'react-intl-universal';
 import PropTypes from 'prop-types';
 import { login } from '../utils/AuthService';
-import AppHeaderMain from '../components/appheader.main';
-import AppFooterMain from '../components/appfooter.main';
 import PurchaseDetailsMain from '../components/purchasedetails.main';
 import cortexFetch from '../utils/Cortex';
 
@@ -86,7 +84,6 @@ class OrderHistoryPage extends React.Component {
     if (purchaseData) {
       return (
         <div>
-          <AppHeaderMain />
           <div className="app-main" style={{ display: 'block' }}>
             <div className="container">
               <h2>
@@ -95,15 +92,12 @@ class OrderHistoryPage extends React.Component {
               <PurchaseDetailsMain data={purchaseData} />
             </div>
           </div>
-          <AppFooterMain />
         </div>
       );
     }
     return (
       <div>
-        <AppHeaderMain />
         <div className="loader" />
-        <AppFooterMain />
       </div>
     );
   }

--- a/src/containers/OrderReviewPage.jsx
+++ b/src/containers/OrderReviewPage.jsx
@@ -24,8 +24,6 @@ import ReactRouterPropTypes from 'react-router-prop-types';
 import intl from 'react-intl-universal';
 import { login } from '../utils/AuthService';
 import { trackAddItemAnalytics, trackAddTransactionAnalytics, sendAnalytics } from '../utils/Analytics';
-import AppHeaderMain from '../components/appheader.main';
-import AppFooterMain from '../components/appfooter.main';
 import PaymentMethodContainer from '../components/paymentmethod.container';
 import ShippingOptionContainer from '../components/shippingoption.container';
 import AddressContainer from '../components/address.container';
@@ -217,7 +215,6 @@ class OrderReviewPage extends React.Component {
     const { orderData, isLoading } = this.state;
     return (
       <div>
-        <AppHeaderMain />
         <div className="app-main" style={{ display: 'block' }}>
           <div className="order-container container">
             <div className="order-container-inner">
@@ -266,7 +263,6 @@ class OrderReviewPage extends React.Component {
             </div>
           </div>
         </div>
-        <AppFooterMain />
       </div>
     );
   }

--- a/src/containers/ProductDetailPage.jsx
+++ b/src/containers/ProductDetailPage.jsx
@@ -20,17 +20,13 @@
  */
 
 import React from 'react';
-import AppHeaderMain from '../components/appheader.main';
-import AppFooterMain from '../components/appfooter.main';
 import ProductDisplayItemMain from '../components/productdisplayitem.main';
 
 function ProductDetailPage(props) {
   return (
     <div>
-      <AppHeaderMain />
       {/* eslint-disable-next-line react/destructuring-assignment,react/prop-types */}
       <ProductDisplayItemMain productUrl={decodeURIComponent(props.match.params.url)} />
-      <AppFooterMain />
     </div>
   );
 }

--- a/src/containers/ProfilePage.jsx
+++ b/src/containers/ProfilePage.jsx
@@ -22,8 +22,6 @@
 import React from 'react';
 import intl from 'react-intl-universal';
 import { login } from '../utils/AuthService';
-import AppHeaderMain from '../components/appheader.main';
-import AppFooterMain from '../components/appfooter.main';
 import ProfileInfoMain from '../components/profileInfo.main';
 import OrderHistoryMain from '../components/orderhistory.main';
 import ProfileAddressesMain from '../components/profileaddresses.main';
@@ -89,7 +87,6 @@ class ProfilePage extends React.Component {
     const { profileData } = this.state;
     return (
       <div>
-        <AppHeaderMain />
         <div className="container">
           <div data-region="profileTitleRegion" style={{ display: 'block' }}>
             <h1>
@@ -105,7 +102,6 @@ class ProfilePage extends React.Component {
             </div>
           ) : <div className="loader" />}
         </div>
-        <AppFooterMain />
       </div>
     );
   }

--- a/src/containers/PurchaseReceiptPage.jsx
+++ b/src/containers/PurchaseReceiptPage.jsx
@@ -22,15 +22,12 @@
 import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import intl from 'react-intl-universal';
-import AppHeaderMain from '../components/appheader.main';
-import AppFooterMain from '../components/appfooter.main';
 import PurchaseDetailsMain from '../components/purchasedetails.main';
 
 const PurchaseReceiptPage = (props) => {
   const { location } = props;
   return (
     <div>
-      <AppHeaderMain />
       <div className="app-main" style={{ display: 'block' }}>
         <div className="container">
           <h2>
@@ -39,7 +36,6 @@ const PurchaseReceiptPage = (props) => {
           <PurchaseDetailsMain data={location.state.data} />
         </div>
       </div>
-      <AppFooterMain />
     </div>
   );
 };

--- a/src/containers/RegistrationPage.jsx
+++ b/src/containers/RegistrationPage.jsx
@@ -20,16 +20,12 @@
  */
 
 import React from 'react';
-import AppHeaderMain from '../components/appheader.main';
-import AppFooterMain from '../components/appfooter.main';
 import RegistrationFormMain from '../components/registrationform.main';
 
 function RegistrationPage() {
   return (
     <div>
-      <AppHeaderMain />
       <RegistrationFormMain />
-      <AppFooterMain />
     </div>
   );
 }

--- a/src/containers/SearchResultsPage.jsx
+++ b/src/containers/SearchResultsPage.jsx
@@ -20,17 +20,13 @@
  */
 
 import React from 'react';
-import AppHeaderMain from '../components/appheader.main';
-import AppFooterMain from '../components/appfooter.main';
 import SearchResultsItemsMain from '../components/searchresultsitems.main';
 
 function SearchResultsPage(props) {
   return (
     <div>
-      <AppHeaderMain />
       {/* eslint-disable-next-line react/destructuring-assignment,react/prop-types */}
       <SearchResultsItemsMain searchKeywordsProps={decodeURIComponent(props.match.params.keywords)} />
-      <AppFooterMain />
     </div>
   );
 }

--- a/src/containers/TermsAndConditionsPage.jsx
+++ b/src/containers/TermsAndConditionsPage.jsx
@@ -21,14 +21,11 @@
 
 import React from 'react';
 import intl from 'react-intl-universal';
-import AppHeaderMain from '../components/appheader.main';
-import AppFooterMain from '../components/appfooter.main';
 
 function TermsAndConditionsPage() {
   return (
     <div className="viewport ui-container static-ui-container" data-region="viewPortRegion" style={{ display: 'block' }}>
       <div>
-        <AppHeaderMain />
         <div className="app-main static-contant-container" data-region="appMain" style={{ display: 'block' }}>
           <div>
             <div className="static-container container">
@@ -51,7 +48,6 @@ function TermsAndConditionsPage() {
             </div>
           </div>
         </div>
-        <AppFooterMain />
       </div>
     </div>
   );


### PR DESCRIPTION
This PR removes `AppHeaderMain` and `AppFooterMain` components from all individual pages and initializes them only once in `App.js` file. This way their life-cycle spans to entire app session instead of individual pages.