### PR TITLE
Collapse mobile header when searching

### DIFF
--- a/src/components/appheader.main.jsx
+++ b/src/components/appheader.main.jsx
@@ -114,7 +114,7 @@ class AppHeaderMain extends React.Component {
 
         </div>
 
-        <div className="collapsable-container collapse collapsed">
+        <div className="collapsable-container collapse">
           <div className="mobile-search-container">
             <AppHeaderSearchMain isMobileView />
           </div>

--- a/src/components/appheadersearch.main.jsx
+++ b/src/components/appheadersearch.main.jsx
@@ -50,6 +50,7 @@ class AppHeaderSearchMain extends React.Component {
     const { history } = this.props;
     const { keywords } = this.state;
     if (keywords !== '') {
+      document.querySelector('.collapsable-container').classList.remove('show');
       history.push(`/search/${keywords}`);
     }
     event.preventDefault();


### PR DESCRIPTION
Description:

This trick collapses the mobile header when user searches for something. Note that this is a total hack and a very non-react way to control UI but it does the trick for now.

We should consider getting rid of Bootstrap or switching to React-Bootstrap in the future. React and jQuery based libraries (which is how collapsing is implemented inside Bootstrap) do not mix well.

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [x] Smoke tests (mvn clean install -Dcucumber.options="--tags @smoketest" from test)
- [x] Manual tests

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
