### PR TITLE
Add dynamic cart item modifier inputs

### DIFF
--- a/src/components/cart.lineitem.jsx
+++ b/src/components/cart.lineitem.jsx
@@ -30,9 +30,6 @@ import {
 import imgPlaceholder from '../images/img-placeholder.png';
 import cortexFetch from '../utils/Cortex';
 import './cart.lineitem.less';
-import epConfig from '../ep.config.json';
-
-const configurationPrefix = epConfig.cartItemModifier.prefix;
 
 const Config = require('Config');
 
@@ -149,9 +146,9 @@ class CartLineItem extends React.Component {
     const keys = Object.keys(item.configuration);
     if (keys) {
       return keys.map(key => (
-        <li className="configuration" key={key.split(configurationPrefix)[1]}>
+        <li className="configuration" key={key}>
           <label htmlFor="option-name" className="option-name">
-            {key.split(configurationPrefix)[1]}
+            {key}
             :&nbsp;
           </label>
           <span>

--- a/src/components/cart.lineitem.jsx
+++ b/src/components/cart.lineitem.jsx
@@ -30,6 +30,9 @@ import {
 import imgPlaceholder from '../images/img-placeholder.png';
 import cortexFetch from '../utils/Cortex';
 import './cart.lineitem.less';
+import epConfig from '../ep.config.json';
+
+const configurationPrefix = epConfig.cartItemModifier.prefix;
 
 const Config = require('Config');
 
@@ -141,6 +144,25 @@ class CartLineItem extends React.Component {
     );
   }
 
+  renderConfiguration() {
+    const { item } = this.props;
+    const keys = Object.keys(item.configuration);
+    if (keys) {
+      return keys.map(key => (
+        <li className="configuration" key={key.split(configurationPrefix)[1]}>
+          <label className="option-name">
+            {key.split(configurationPrefix)[1]}
+            :&nbsp;
+          </label>
+          <span>
+            {item.configuration[key]}
+          </span>
+        </li>
+      ));
+    }
+    return null;
+  }
+
   renderOptions() {
     const { item } = this.props;
     const options = item._item[0]._definition[0]._options;
@@ -197,6 +219,7 @@ class CartLineItem extends React.Component {
         <div className="options-col">
           <ul className="options-container">
             {this.renderOptions()}
+            {this.renderConfiguration()}
           </ul>
         </div>
         <div className="availability-col" data-region="cartLineitemAvailabilityRegion">

--- a/src/components/cart.lineitem.jsx
+++ b/src/components/cart.lineitem.jsx
@@ -150,7 +150,7 @@ class CartLineItem extends React.Component {
     if (keys) {
       return keys.map(key => (
         <li className="configuration" key={key.split(configurationPrefix)[1]}>
-          <label className="option-name">
+          <label htmlFor="option-name" className="option-name">
             {key.split(configurationPrefix)[1]}
             :&nbsp;
           </label>

--- a/src/components/productdisplayitem.main.jsx
+++ b/src/components/productdisplayitem.main.jsx
@@ -31,7 +31,6 @@ import {
 import imgPlaceholder from '../images/img-placeholder.png';
 import ProductRecommendationsDisplayMain from './productrecommendations.main';
 import cortexFetch from '../utils/Cortex';
-import epConfig from '../ep.config.json';
 
 import './productdisplayitem.main.less';
 
@@ -63,8 +62,6 @@ const zoomArray = [
   'recommendations:warranty',
   'code',
 ];
-
-const configurationPrefix = epConfig.cartItemModifier.prefix;
 
 class ProductDisplayItemMain extends React.Component {
   static propTypes = {
@@ -169,10 +166,7 @@ class ProductDisplayItemMain extends React.Component {
   }
 
   handleConfiguration(configuration, event) {
-    let { itemConfiguration } = this.state;
-    if (!itemConfiguration) {
-      itemConfiguration = {};
-    }
+    const { itemConfiguration } = this.state;
     itemConfiguration[configuration] = event.target.value;
     this.setState({ itemConfiguration });
   }
@@ -212,6 +206,11 @@ class ProductDisplayItemMain extends React.Component {
     const { history } = this.props;
     login().then(() => {
       const addToCartLink = productData._addtocartform[0].links.find(link => link.rel === 'addtodefaultcartaction');
+      const body = {};
+      body.quantity = itemQuantity;
+      if (itemConfiguration) {
+        body.configuration = itemConfiguration;
+      }
       cortexFetch(addToCartLink.uri,
         {
           method: 'post',
@@ -219,10 +218,7 @@ class ProductDisplayItemMain extends React.Component {
             'Content-Type': 'application/json',
             Authorization: localStorage.getItem(`${Config.cortexApi.scope}_oAuthToken`),
           },
-          body: JSON.stringify({
-            quantity: itemQuantity,
-            configuration: itemConfiguration,
-          }),
+          body: JSON.stringify(body),
         })
         .then((res) => {
           if (res.status === 200 || res.status === 201) {
@@ -307,11 +303,11 @@ class ProductDisplayItemMain extends React.Component {
       const keys = Object.keys(productData._addtocartform[0].configuration);
       return keys.map(key => (
         <div key={key} className="form-group">
-          <label htmlFor={`product_display_item_configuration_${key.split(configurationPrefix)[1]}_label`} className="control-label">
-            {key.split(configurationPrefix)[1]}
+          <label htmlFor={`product_display_item_configuration_${key}_label`} className="control-label">
+            {key}
           </label>
           <div className="form-content">
-            <input className="form-control form-control-text" disabled={isLoading} onChange={e => this.handleConfiguration(key, e)} id={`product_display_item_configuration_${key.split(configurationPrefix)[1]}_label`} value={productData._addtocartform[0].configuration.key} />
+            <input className="form-control form-control-text" disabled={isLoading} onChange={e => this.handleConfiguration(key, e)} id={`product_display_item_configuration_${key}_label`} value={productData._addtocartform[0].configuration.key} />
           </div>
         </div>
       ));

--- a/src/components/productdisplayitem.main.less
+++ b/src/components/productdisplayitem.main.less
@@ -102,6 +102,10 @@
             background-position: 152px;
             background-size: 16px 9px;
           }
+
+          .form-control-text {
+            background: #fff;
+          }
         }
       }
     }

--- a/src/ep.config.json
+++ b/src/ep.config.json
@@ -33,8 +33,5 @@
   "arKit": {
     "enable": true,
     "skuArImagesUrl": "https://s3.amazonaws.com/referenceexp/ar/%sku%.usdz"
-  },
-  "cartItemModifier": {
-    "prefix": "SIG_"
   }
 }

--- a/src/ep.config.json
+++ b/src/ep.config.json
@@ -33,5 +33,8 @@
   "arKit": {
     "enable": true,
     "skuArImagesUrl": "https://s3.amazonaws.com/referenceexp/ar/%sku%.usdz"
+  },
+  "cartItemModifier": {
+    "prefix": "SIG_"
   }
 }


### PR DESCRIPTION
Description:
Added dynamic Cart Item Modifier inputs on the cart page and the product details page

Linting:
- [x] No linting errors

Tests:
- [x] Smoke tests (mvn clean install -Dcucumber.options="--tags @smoketest" from test)
- [x] Manual tests

Documentation:
- [x] Requires documentation updates
It is required to have a configuration object in ep.config.json that contains a "prefix" attribute that is the one used in the cart item modifier object.
For example: If you add a new item modifier input that is called "test", you will most likely give it the name "VESTRI_test" if you are using the Vestri store. Then you should have the following: 
```
"configuration": {
    "prefix": "VESTRI_"
}
```