### PR TITLE
Nginx changes for domain and SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,12 @@ For more information about populating database, see the [Populating the Database
 3. Run a Production Docker Image:
     1. In the repository, navigate to the `docker/prod/` directory.
     2. Copy the `docker-compose.yaml` and `nginx.conf` files to a folder on the remote host.
-    3. Replace the `$CORTEX_URL` parameter in the `nginx.conf` file with a Cortex server URL.
-    4. Replace the `$DOCKER_REPO` parameter in the `docker-compose.yaml` file with `ep-store`.
+    3. On a remote host search and replace the following parameters in `docker-compose.yaml` and `nginx.conf` files:
+        - Replace the `$CORTEX_URL` parameter in the `nginx.conf` file with a Cortex server URL.
+        - Replace the `$DOCKER_REPO` parameter in the `docker-compose.yaml` file with `ep-store`.
+        - Replace the `$DOMAIN` parameter in `nginx.conf` with the domain name (excluding the `http://` part, eg. `www.domain.com`) where you plan to host the site.
+        - Replace the `$SSL_CERT_PATH` in `nginx.conf` and `docker-compose.yaml` with the path of the certificate file on the remove server (eg. `/etc/letsencrypt/live/reference.elasticpath.com/fullchain.pem`).
+        - Replace the `$SSL_KEY_PATH` in `nginx.conf` and `docker-compose.yaml` with the path of the private key on the remote server (eg. `/etc/letsencrypt/live/reference.elasticpath.com/privkey.pem`).
     5. Run the `docker-compose up -d` command.
 
 ## Running a Linter

--- a/docker/prod/docker-compose.yaml
+++ b/docker/prod/docker-compose.yaml
@@ -2,5 +2,8 @@ web:
   image: $DOCKER_REPO
   volumes:
    - ./nginx.conf:/etc/nginx/nginx.conf
+   - $SSL_CERT_PATH:$SSL_CERT_PATH
+   - $SSL_KEY_PATH:$SSL_KEY_PATH
   ports:
    - "80:80"
+   - "443:443"

--- a/docker/prod/nginx.conf
+++ b/docker/prod/nginx.conf
@@ -24,8 +24,20 @@ http {
     keepalive_timeout  65;
 
     server {
-        listen       80;
-        server_name  localhost;
+        listen 80;
+        server_name $DOMAIN;
+
+        location / {
+            return 301 https://$DOMAIN$request_uri;
+        }
+    }
+
+    server {
+        listen 443 ssl;
+        server_name $DOMAIN;
+
+        ssl_certificate $SSL_CERT_PATH;
+        ssl_certificate_key $SSL_KEY_PATH;
 
         location /cortex {
             proxy_pass       $CORTEX_URL;


### PR DESCRIPTION
Description:
PR adds `reference.elasticpath.com` domain to `nginx.conf` as well as making necessary changes to enable SSL protocol.

Documentation:
I've made changes to README.md.
- [x] Requires documentation updates

