### PR TITLE
Display lineitem promotions

### DIFF
--- a/src/components/cart.lineitem.jsx
+++ b/src/components/cart.lineitem.jsx
@@ -219,6 +219,25 @@ class CartLineItem extends React.Component {
     return null;
   }
 
+  renderPromotions() {
+    const { item } = this.props;
+    if (item._appliedpromotions) {
+      const promotions = item._appliedpromotions[0]._element;
+      if (promotions) {
+        return (
+          promotions.map(promotion => (
+            <li key={promotion.name}>
+              {(promotion['display-name'])
+                ? (promotion['display-name'])
+                : (promotion.name)}
+              &nbsp;
+            </li>
+          )));
+      }
+    }
+    return null;
+  }
+
   render() {
     const { item } = this.props;
     const { quantity } = this.state;
@@ -260,6 +279,20 @@ class CartLineItem extends React.Component {
             {item._item[0]._definition[0]['display-name']}
           </Link>
         </div>
+        {(item._appliedpromotions[0]._element)
+          ? (
+            <div className="promotions-col">
+              <ul className="promotions-container">
+                <label htmlFor="promotions-container" className="cart-summary-label-col">
+                  {intl.get('applied-promotions')}
+                  :&nbsp;
+                </label>
+                {this.renderPromotions()}
+              </ul>
+            </div>)
+          : ('')
+        }
+        
         <div className="options-col">
           <ul className="options-container">
             {this.renderOptions()}

--- a/src/components/cart.lineitem.jsx
+++ b/src/components/cart.lineitem.jsx
@@ -292,7 +292,6 @@ class CartLineItem extends React.Component {
             </div>)
           : ('')
         }
-        
         <div className="options-col">
           <ul className="options-container">
             {this.renderOptions()}

--- a/src/components/cart.lineitem.jsx
+++ b/src/components/cart.lineitem.jsx
@@ -279,7 +279,7 @@ class CartLineItem extends React.Component {
             {item._item[0]._definition[0]['display-name']}
           </Link>
         </div>
-        {(item._appliedpromotions[0]._element)
+        {(item._appliedpromotions && item._appliedpromotions[0]._element)
           ? (
             <div className="promotions-col">
               <ul className="promotions-container">

--- a/src/components/cart.lineitem.less
+++ b/src/components/cart.lineitem.less
@@ -61,13 +61,9 @@
   }
 
   .promotions-col {
-    display: inline-block;
+    display: block;
     width: 33%;
-    text-align: right;
-    @media (max-width: @mobileWidth - 1px) {
-      width: 100%;
-      text-align: left;
-    }
+    text-align: left;
   }
   
   .availability-col {

--- a/src/components/cart.lineitem.less
+++ b/src/components/cart.lineitem.less
@@ -36,6 +36,7 @@
     position: relative;
     display: inline-block;
     margin-right: 10px;
+    vertical-align: top;
     img {
       max-width: 60px;
     }
@@ -51,6 +52,7 @@
     font-weight: bold;
     padding-bottom: 3px;
     width: 60%;
+    vertical-align: top;
   }
 
   .options-col {
@@ -58,6 +60,16 @@
     width: 50%;
   }
 
+  .promotions-col {
+    display: inline-block;
+    width: 33%;
+    text-align: right;
+    @media (max-width: @mobileWidth - 1px) {
+      width: 100%;
+      text-align: left;
+    }
+  }
+  
   .availability-col {
     display: inline-block;
     width: 50%;

--- a/src/components/checkout.summarylist.jsx
+++ b/src/components/checkout.summarylist.jsx
@@ -99,7 +99,10 @@ class CheckoutSummaryList extends React.Component {
           <br />
           {data._appliedpromotions[0]._element.map(promotion => (
             <span className="cart-summary-value-col cart-applied-promotions" key={promotion.name}>&nbsp;&nbsp;
-              {promotion['display-name']}
+              {(promotion['display-name'])
+                ? (promotion['display-name'])
+                : (promotion.name)
+              }
               &nbsp;&nbsp;
             </span>
           ))}


### PR DESCRIPTION
Description:
Cart lineitems now show the values from the `appliedpromotions` resource.  Also, changed the cart applied promotions to display a promotions `name` if it does not have a `display-name`, otherwise a blank line is all that appears.

Linting:
- [x] No linting errors

Tests:
- [x] Smoke tests (mvn clean install -Dcucumber.options="--tags @smoketest" from test)
- [x] Manual tests

To test the changes manually, add a Cart Promotion that discounts a certain product when it is in your cart.  Add that item to the cart, and you will see the promotion name in the upper right hand corner of the cart line item

Documentation:
- [ ] Requires documentation updates
