### PR TITLE
Adjust modal login to be full length of screen if mobile aspect ratio…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.idea
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/components/appmodallogin.main.jsx
+++ b/src/components/appmodallogin.main.jsx
@@ -89,40 +89,28 @@ class AppModalLoginMain extends React.Component {
 
   render() {
     const { failedLogin, isLoading } = this.state;
-
     return (
       <div className="modal login-modal-content" id="login-modal">
         <div className="modal-dialog">
           <div className="modal-content" id="simplemodal-container">
-
-            <div className="modal-header">
-              <h2 className="modal-title">
-                {intl.get('login')}
-              </h2>
-              <button type="button" id="login_modal_close_button" className="close" data-dismiss="modal">
-                &times;
-              </button>
-            </div>
-
-            <div className="feedback-label auth-feedback-container" id="login_modal_auth_feedback_container" data-region="authLoginFormFeedbackRegion" data-i18n="">
-              {failedLogin ? (intl.get('invalid-username-or-password')) : ('')}
-            </div>
-
-            <div className="modal-body">
+            <button type="button" id="login_modal_close_button" className="close" data-dismiss="modal">
+              &times;
+            </button>
+            <div className="form-container">
+              <div className="panel">
+                <h2>
+                  {intl.get('login')}
+                </h2>
+              </div>
               <form id="login_modal_form" onSubmit={this.loginRegisteredUser}>
                 <div className="form-group">
-                  <span>
-                    {intl.get('username')}
-                    :
-                  </span>
-                  <input className="form-control" id="login_modal_username_input" type="text" onChange={this.setUsername} />
+                  <input className="form-control" id="login_modal_username_input" placeholder="Email Address" type="text" onChange={this.setUsername} />
                 </div>
                 <div className="form-group">
-                  <span>
-                    {intl.get('password')}
-                    :
-                  </span>
-                  <input className="form-control" id="login_modal_password_input" type="password" onChange={this.setPassword} />
+                  <input className="form-control" id="login_modal_password_input" placeholder="Password" type="password" onChange={this.setPassword} />
+                </div>
+                <div className="feedback-label auth-feedback-container" id="login_modal_auth_feedback_container" data-region="authLoginFormFeedbackRegion" data-i18n="">
+                  {failedLogin ? (intl.get('invalid-username-or-password')) : ('')}
                 </div>
                 <div className="form-group action-row">
                   {

--- a/src/components/appmodallogin.main.less
+++ b/src/components/appmodallogin.main.less
@@ -22,6 +22,7 @@
  @import './../style/common.less';
 
 .login-modal-content {
+
   #login_modal_form {
     span {
       display: inline-block;
@@ -35,7 +36,6 @@
       padding: 6px 12px;
       font-size: 14px;
       color: #555555;
-      background-color: #ffffff;
       border: 1px solid #cccccc;
       border-radius: 4px;
       box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
@@ -57,10 +57,36 @@
 
   #login_modal_close_button {
     font-size: 30px;
+    text-align: right;
   }
 
   .form-input.btn-container {
     padding-top: 15px;
+  }
+
+  .form-container {
+    margin: auto 30px;
+    text-align: center;
+  }
+
+  .form-control {
+    background: #f7f7f7 none repeat scroll 0 0;
+  }
+
+  .panel {
+    margin-bottom: 10%
+  }
+
+  @media (max-width: @mobileWidth - 1) {
+    .modal-dialog {
+      height: 98.5%;
+    }
+  }
+
+  @media (max-width: @mobileWidth - 1) {
+    .modal-content {
+      height: 100%;
+    }
   }
 
 }


### PR DESCRIPTION
…, and adjust styling of login form itself

This PR:

1. adjusts the modal form to fit the entire height of the screen if it is a mobile device.
2. adjusts styling of the modal form itself by aligning all elements to the centre, getting rid of `username` and `password` headers on top of text input and moving position and color of the error text.

How to test? 
Test all buttons on the form in both desktop and mobile view