### PR TITLE
Adjust modal login to be full length of screen if mobile aspect ratio…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.idea
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/components/appmodallogin.main.jsx
+++ b/src/components/appmodallogin.main.jsx
@@ -104,7 +104,7 @@ class AppModalLoginMain extends React.Component {
               </div>
               <form id="login_modal_form" onSubmit={this.loginRegisteredUser}>
                 <div className="form-group">
-                  <input className="form-control" id="login_modal_username_input" placeholder={intl.get('username')} type="text" onChange={this.setUsername} />
+                  <input className="form-control" id="login_modal_username_input" placeholder={intl.get('email-slash-username')} type="text" onChange={this.setUsername} />
                 </div>
                 <div className="form-group">
                   <input className="form-control" id="login_modal_password_input" placeholder={intl.get('password')} type="password" onChange={this.setPassword} />

--- a/src/components/appmodallogin.main.jsx
+++ b/src/components/appmodallogin.main.jsx
@@ -104,10 +104,10 @@ class AppModalLoginMain extends React.Component {
               </div>
               <form id="login_modal_form" onSubmit={this.loginRegisteredUser}>
                 <div className="form-group">
-                  <input className="form-control" id="login_modal_username_input" placeholder="Email Address" type="text" onChange={this.setUsername} />
+                  <input className="form-control" id="login_modal_username_input" placeholder={intl.get('username')} type="text" onChange={this.setUsername} />
                 </div>
                 <div className="form-group">
-                  <input className="form-control" id="login_modal_password_input" placeholder="Password" type="password" onChange={this.setPassword} />
+                  <input className="form-control" id="login_modal_password_input" placeholder={intl.get('password')} type="password" onChange={this.setPassword} />
                 </div>
                 <div className="feedback-label auth-feedback-container" id="login_modal_auth_feedback_container" data-region="authLoginFormFeedbackRegion" data-i18n="">
                   {failedLogin ? (intl.get('invalid-username-or-password')) : ('')}

--- a/src/components/appmodallogin.main.jsx
+++ b/src/components/appmodallogin.main.jsx
@@ -89,40 +89,28 @@ class AppModalLoginMain extends React.Component {
 
   render() {
     const { failedLogin, isLoading } = this.state;
-
     return (
       <div className="modal login-modal-content" id="login-modal">
         <div className="modal-dialog">
           <div className="modal-content" id="simplemodal-container">
-
-            <div className="modal-header">
-              <h2 className="modal-title">
-                {intl.get('login')}
-              </h2>
-              <button type="button" id="login_modal_close_button" className="close" data-dismiss="modal">
-                &times;
-              </button>
-            </div>
-
-            <div className="feedback-label auth-feedback-container" id="login_modal_auth_feedback_container" data-region="authLoginFormFeedbackRegion" data-i18n="">
-              {failedLogin ? (intl.get('invalid-username-or-password')) : ('')}
-            </div>
-
-            <div className="modal-body">
+            <button type="button" id="login_modal_close_button" className="close" data-dismiss="modal">
+              &times;
+            </button>
+            <div className="form-container">
+              <div className="panel">
+                <h2>
+                  {intl.get('login')}
+                </h2>
+              </div>
               <form id="login_modal_form" onSubmit={this.loginRegisteredUser}>
                 <div className="form-group">
-                  <span>
-                    {intl.get('username')}
-                    :
-                  </span>
-                  <input className="form-control" id="login_modal_username_input" type="text" onChange={this.setUsername} />
+                  <input className="form-control" id="login_modal_username_input" placeholder="Email Address" type="text" onChange={this.setUsername} />
                 </div>
                 <div className="form-group">
-                  <span>
-                    {intl.get('password')}
-                    :
-                  </span>
-                  <input className="form-control" id="login_modal_password_input" type="password" onChange={this.setPassword} />
+                  <input className="form-control" id="login_modal_password_input" placeholder="Password" type="password" onChange={this.setPassword} />
+                </div>
+                <div className="feedback-label auth-feedback-container" id="login_modal_auth_feedback_container" data-region="authLoginFormFeedbackRegion" data-i18n="">
+                  {failedLogin ? (intl.get('invalid-username-or-password')) : ('')}
                 </div>
                 <div className="form-group action-row">
                   {

--- a/src/components/appmodallogin.main.less
+++ b/src/components/appmodallogin.main.less
@@ -80,6 +80,8 @@
   @media (max-width: @mobileWidth - 1) {
     .modal-dialog {
       height: 98.5%;
+      max-width: 100%;
+      margin: .5rem;
     }
   }
 

--- a/src/components/appmodallogin.main.less
+++ b/src/components/appmodallogin.main.less
@@ -31,7 +31,7 @@
     }
 
     .form-control {
-      display: block;
+      display: inline-block;
       height: 34px;
       padding: 6px 12px;
       font-size: 14px;
@@ -39,6 +39,12 @@
       border: 1px solid #cccccc;
       border-radius: 4px;
       box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+      max-width: 414px;
+      background: #f7f7f7 none repeat scroll 0 0;
+    }
+
+    .form-control:focus {
+      background: #ffffff none repeat scroll 0 0;
     }
   }
 
@@ -67,10 +73,6 @@
   .form-container {
     margin: auto 30px;
     text-align: center;
-  }
-
-  .form-control {
-    background: #f7f7f7 none repeat scroll 0 0;
   }
 
   .panel {

--- a/src/components/appmodallogin.main.less
+++ b/src/components/appmodallogin.main.less
@@ -22,6 +22,7 @@
  @import './../style/common.less';
 
 .login-modal-content {
+
   #login_modal_form {
     span {
       display: inline-block;
@@ -35,7 +36,6 @@
       padding: 6px 12px;
       font-size: 14px;
       color: #555555;
-      background-color: #ffffff;
       border: 1px solid #cccccc;
       border-radius: 4px;
       box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
@@ -57,10 +57,36 @@
 
   #login_modal_close_button {
     font-size: 30px;
+    text-align: right;
   }
 
   .form-input.btn-container {
     padding-top: 15px;
+  }
+
+  .form-container {
+    margin: auto 30px;
+    text-align: center;
+  }
+
+  .form-control {
+    background: #f7f7f7 none repeat scroll 0 0;
+  }
+
+  .panel {
+    margin-bottom: 10%
+  }
+
+  @media (max-width: @mobileWidth - 1) {
+    .modal-dialog {
+      height: 98.5%;
+    }
+  }
+
+  @media (max-width: @mobileWidth - 1) {
+    .modal-content {
+      height: 100%;
+    }
   }
 
 }


### PR DESCRIPTION
…, and adjust styling of login form itself

Description:
The modal login form has been adjusted to fit the entire height of the screen if it is a mobile device.  got rid of `username` and `password` headers on top of text input and moved position and color of the error text.

Linting:
- [x] No linting errors

Tests:
- [x] Smoke tests (mvn clean install -Dcucumber.options="--tags @smoketest" from test)
- [x] Manual tests

Documentation:
- [ ] Requires documentation updates
