### PR TITLE
[Resolves #268] Fix faceted search when scope is not lowercase

### DIFF
--- a/src/utils/CortexLookup.js
+++ b/src/utils/CortexLookup.js
@@ -495,7 +495,7 @@ export function purchaseLookup(purchaseLookupCode) {
 
 export function searchLookup(searchKeyword) {
   return new Promise(((resolve, reject) => {
-    if (searchKeyword.includes('/') && searchKeyword.includes(Config.cortexApi.scope)) {
+    if (searchKeyword.includes('/') && searchKeyword.includes(Config.cortexApi.scope.toLowerCase())) {
       cortexFetch(`/${searchKeyword}?zoom=${searchFormZoomArray.join()}`,
         {
           headers: {


### PR DESCRIPTION
Description:
Adjusted check in searchLookup to compare a lowercase scope string regardless of the value in the configuration file.

Resolves this issue: https://github.com/elasticpath/react-pwa-reference-storefront/issues/268

Linting:
- [x] No linting errors

Tests:
- [x] E2E tests (npm test run with `e2e`)
- [x] Manual tests

Documentation:
- [ ] Requires documentation updates
