### PR TITLE
Fixed Order Status messaging

### DIFF
--- a/src/components/orderline.main.jsx
+++ b/src/components/orderline.main.jsx
@@ -41,7 +41,7 @@ class OrderLine extends React.Component {
     const {
       purchase,
     } = this.state;
-    const { status } = purchase.status;
+    const { status } = purchase;
     let statusString;
     switch (status) {
       case 'CANCELLED':


### PR DESCRIPTION
Description:
The order status switch case value was trying to destructure a string.  As a result, all orders used the default In Progress case, and Completed orders were being shown as In Progress.  Now the correct value is being compared in the switch and the correct value is being displayed.

Linting:
- [x] No linting errors

Tests:
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests
Checked the order status against completed orders, now it displays completed.

Documentation:
- [ ] Requires documentation updates
