### PR TITLE
Only displays region if address contains one

### DIFF
--- a/src/components/address.container.jsx
+++ b/src/components/address.container.jsx
@@ -43,10 +43,13 @@ const AddressContainer = (props) => {
           {address.locality}
           ,&nbsp;
         </span>
-        <span className="address-region">
-          {address.region}
-          ,&nbsp;
-        </span>
+        {(address.region)
+          ? (
+            <span className="address-region">
+              {address.region}
+              ,&nbsp;
+            </span>
+          ) : ('')}
         <span className="address-country">
           {address['country-name']}
           &nbsp;

--- a/src/components/address.container.jsx
+++ b/src/components/address.container.jsx
@@ -43,13 +43,12 @@ const AddressContainer = (props) => {
           {address.locality}
           ,&nbsp;
         </span>
-        {(address.region)
-          ? (
-            <span className="address-region">
-              {address.region}
-              ,&nbsp;
-            </span>
-          ) : ('')}
+        <span className="address-region">
+          {(address.region)
+            ? (
+              `${address.region}, `
+            ) : ('')}
+        </span>
         <span className="address-country">
           {address['country-name']}
           &nbsp;

--- a/src/components/profileaddresses.main.jsx
+++ b/src/components/profileaddresses.main.jsx
@@ -89,13 +89,13 @@ class ProfileAddressesMain extends React.Component {
                       <span className="address-city" data-el-value="address.city">
                         {`${address.locality}, `}
                       </span>
-                      {(address.region)
-                        ? (
-                          <span className="address-region" data-el-value="address.region">
-                            {`${address.region}, `}
-                          </span>
-                        ) : ('')
-                      }
+                      <span className="address-region" data-el-value="address.region">
+                        {(address.region)
+                          ? (
+                            `${address.region}, `
+                          ) : ('')
+                        }
+                      </span>
                       <span className="address-country" data-el-value="address.country">
                         {`${address['country-name']}, `}
                       </span>

--- a/src/components/profileaddresses.main.jsx
+++ b/src/components/profileaddresses.main.jsx
@@ -89,9 +89,13 @@ class ProfileAddressesMain extends React.Component {
                       <span className="address-city" data-el-value="address.city">
                         {`${address.locality}, `}
                       </span>
-                      <span className="address-region" data-el-value="address.region">
-                        {`${address.region}, `}
-                      </span>
+                      {(address.region)
+                        ? (
+                          <span className="address-region" data-el-value="address.region">
+                            {`${address.region}, `}
+                          </span>
+                        ) : ('')
+                      }
                       <span className="address-country" data-el-value="address.country">
                         {`${address['country-name']}, `}
                       </span>


### PR DESCRIPTION
Description:
In the AddressContainer and ProfileAddressesMain it is assumed that there will be a region to display in the address.  This fix removes the `null, `, or empty commas values that are displayed 

Linting:
- [x] No linting errors

Tests:
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests
1. Create a new address in a country with no regions (ex. Great Britain)
2. Navigate to `/profile` and verify that the address their no longer contains a `null, `
3. Navigate to `/checkout` and verify that the address no longer contains an empty set of commas.

Documentation:
- [ ] Requires documentation updates
