### PR TITLE
Faceted search and B2B login scope case sensitivity

### DIFF
--- a/src/components/appmodalcartselect.main.jsx
+++ b/src/components/appmodalcartselect.main.jsx
@@ -67,7 +67,7 @@ class AppModalCartSelectMain extends React.Component {
     })
       .then(res => res.json())
       .then((res) => {
-        const orgAuthServiceData = res._authorizationcontexts[0]._element.find(element => element.name === Config.cortexApi.scope.toUpperCase());
+        const orgAuthServiceData = res._authorizationcontexts[0]._element.find(element => element.name.toUpperCase() === Config.cortexApi.scope.toUpperCase());
         this.setState({
           orgAuthServiceData,
         });

--- a/src/components/searchresultsitems.main.jsx
+++ b/src/components/searchresultsitems.main.jsx
@@ -103,7 +103,7 @@ class SearchResultsItemsMain extends React.Component {
       <div className="category-items-container container-3">
         <div data-region="categoryTitleRegion">
           {
-            ((typeof searchKeywords === 'object' || searchKeywords instanceof Object) || ((typeof searchKeywords === 'string' || searchKeywords instanceof String) && searchKeywords.includes('/') && searchKeywords.includes(Config.cortexApi.scope))) ? (
+            ((typeof searchKeywords === 'object' || searchKeywords instanceof Object) || ((typeof searchKeywords === 'string' || searchKeywords instanceof String) && searchKeywords.includes('/') && searchKeywords.includes(Config.cortexApi.scope.toLowerCase()))) ? (
               <h1 className="view-title">
                 {intl.get('search-results')}
               </h1>


### PR DESCRIPTION
Description:
1. Using the faceted search facets on the search results page displays the incorrect title if the scope in ep.config.json is uppercase, since the check for the scope in searchKeywords uses includes() which is case sensitive.
Fix: Added toLowerCase() for Config.cortexApi.scope to make it case insensitive.

2. After B2B login, the modal for selecting who to shop for won't show the accounts/subaccounts if the store reference value in TSTOREREF table(DB on account management server) is in lower case, since it is compared to the Config.cortexApi.scope which is being converted to upper case.
Fix: Added toUpperCase() to authorizationcontexts element name to make it case insensitive.

Linting:
- [X] No linting errors

Tests:
- [ ] E2E tests (npm test run with `e2e`)
- [X] Manual tests

1. Set the scope in ep.config.json to uppercase, verify that the title for faceted search displays "Search results for: {keywords}" if there are results found. Also verify that this still works for lowercase scope.
2. Using an AM server with lowercase value for TSTOREREF: 
i. login with B2B enabled and a properly configured B2B user
ii. verify that the modal shows the correct accounts/subaccounts.

Documentation:
- [ ] Requires documentation updates
