### PR TITLE
Fixed case sensitive check for applicable scopes in b2b authentication

### DIFF
--- a/src/components/appmodalcartselect.main.jsx
+++ b/src/components/appmodalcartselect.main.jsx
@@ -67,7 +67,7 @@ class AppModalCartSelectMain extends React.Component {
     })
       .then(res => res.json())
       .then((res) => {
-        const orgAuthServiceData = res._authorizationcontexts[0]._element.find(element => element.name === Config.cortexApi.scope.toUpperCase());
+        const orgAuthServiceData = res._authorizationcontexts[0]._element.find(element => element.name.toUpperCase() === Config.cortexApi.scope.toUpperCase());
         this.setState({
           orgAuthServiceData,
         });


### PR DESCRIPTION
Description:
When logging in into B2B mode, a check is made comparing the `cortexApi.scope` config value transformed into an upper case string to the store codes returned from the AM API.  There is no requirement in AM, or EP Commerce, that a store code be all uppercase. If the store code was not configured in uppercase in AM, a message appears saying the user has no accounts assigned with shopping access.

This changes the comparison so that both strings are transformed into uppercase.

Linting:
- [x] No linting errors

Tests:
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests
I used it to authenticate against a lowercase store in b2b mode. 

Documentation:
- [ ] Requires documentation updates
