### PR TITLE
RS-446 - Fix routing between related products and bundle constituents in the PDP

### DIFF
--- a/app/src/containers/ProductDetailPage.tsx
+++ b/app/src/containers/ProductDetailPage.tsx
@@ -45,7 +45,7 @@ function ProductDetailPage(props) {
   return (
     <div>
       {/* eslint-disable-next-line react/destructuring-assignment,react/prop-types */}
-      <ProductDisplayItemMain productId={decodeURIComponent(props.match.params.url)} onChangeProductFeature={handleChangeProductFeature} onAddToCart={handleAddToCart} onAddToWishList={handleAddToWishList} productLink={handleProductLink} isInStandaloneMode={isInStandaloneMode} />
+      <ProductDisplayItemMain productId={decodeURIComponent(props.match.params.url)} onChangeProductFeature={handleChangeProductFeature} onAddToCart={handleAddToCart} onAddToWishList={handleAddToWishList} productLink={handleProductLink} isInStandaloneMode={isInStandaloneMode} itemDetailLink={'/itemdetail'} />
     </div>
   );
 }


### PR DESCRIPTION
Description:
<!--A brief description of changes. Things to include: WIP? Dependent PR's opened against other tickets? -->
This is a fix for #335.

This is a fix in the PDP of the CRA.

Before this fix the routing to any bundle constituents as well as crosssell items was broken.  

https://jira.elasticpath.com/browse/RS-446

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests

Head to a product with crosssell items or bundle constituents and notice that clicking on the item properly routes you to the respective PDP.

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
