### PR TITLE
Added same code to remove expired auth information to cortexFetch as adminFetch

### DIFF
--- a/components/src/utils/Cortex.js
+++ b/components/src/utils/Cortex.js
@@ -37,6 +37,18 @@ export function cortexFetch(input, init) {
 
   return fetch(`${Config.cortexApi.path + input}`, requestInit)
     .then((res) => {
+      if (res.status === 401 || res.status === 403) {
+        localStorage.removeItem(`${Config.cortexApi.scope}_oAuthRole`);
+        localStorage.removeItem(`${Config.cortexApi.scope}_oAuthScope`);
+        localStorage.removeItem(`${Config.cortexApi.scope}_oAuthToken`);
+        localStorage.removeItem(`${Config.cortexApi.scope}_oAuthUserName`);
+        localStorage.removeItem(`${Config.cortexApi.scope}_b2bCart`);
+        localStorage.removeItem(`${Config.cortexApi.scope}_oAuthTokenAuthService`);
+        localStorage.removeItem(`${Config.cortexApi.scope}_keycloakSessionState`);
+        localStorage.removeItem(`${Config.cortexApi.scope}_keycloakCode`);
+        window.location.pathname = '/';
+        window.location.reload();
+      }
       if (res.status >= 500) {
         if (window.location.href.indexOf('/maintenance') === -1) {
           window.location.pathname = '/maintenance';


### PR DESCRIPTION
Description:
Currently, a Cortex token expires after 7 days, and no refresh_token is available to renew the user's session.  Once the token expires, all Cortex requests return a 401.

When I went to look at implementing a solution to remove bad credentials I noticed that the `Cortex.js#adminFetch` already had a solution to this problem, so I copied it to `cortexFetch`.  I included the `b2b` mode settings to get wiped as well just in case.

Linting:
- [ ] No linting errors
eslint is currently not working in the project

Tests:
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests
1. Run the PWA locally
2. Copy the bearer token from local storage to the `Authorization` header field in Cortex studio for whatever instance you are pointed at.
3. Revoke Access for that token
4. Refresh the PWA.  You should see the page reload with a fresh PUBLIC token and no 401s.

Documentation:
- [ ] Requires documentation updates
