### PR TITLE
Brought in styling from common.less to search input

### DIFF
--- a/components/src/AppHeaderSearch/appheadersearch.main.less
+++ b/components/src/AppHeaderSearch/appheadersearch.main.less
@@ -36,7 +36,7 @@
       transition: width 0.5s ease,
                   border-color 0.5s,
                   padding 0.5s ease-in;
-      color: #fff;
+      color: @mainNavigationTextColor;
       cursor: pointer;
       outline: 0;
       border: 0;
@@ -45,13 +45,13 @@
 
       &::placeholder {
         opacity: 0.3;
-        color: #fff;
+        color: @mainNavigationTextColor;
       }
 
       &:focus {
         width: 170px;
         padding-left: 40px;
-        border-bottom: 1px solid #fff;
+        border-bottom: 1px solid @mainNavigationTextColor;
         cursor: auto;
       }
     }


### PR DESCRIPTION
Description:
Brought in styling from common.less to make restyling easier and more consistent.  Currently, the colors for the search input are hard-coded.  When the mainColor variable is set to white or off-white, the search text is not visible unless it is specifically changed.  Now it matches the other text in the header

Linting:
- [x] No linting errors

Tests:
- [ ] E2E tests (npm test run with `e2e`)
- [ ] Manual tests

Documentation:
- [ ] Requires documentation updates
