### PR TITLE
Updated text color styles for locale and login

### DIFF
--- a/components/src/AppHeaderLocale/appheaderlocale.main.less
+++ b/components/src/AppHeaderLocale/appheaderlocale.main.less
@@ -40,7 +40,7 @@
     font-size: 13px;
     border: 0;
     background-color: transparent;
-    color: @mainBackgroundColor;
+    color: @mainNavigationTextColor;
     cursor: pointer;
 
     &:focus {

--- a/components/src/AppHeaderLogin/appheaderlogin.main.less
+++ b/components/src/AppHeaderLogin/appheaderlogin.main.less
@@ -29,7 +29,7 @@
   .login-btn {
     background-color: transparent;
     border: 0;
-    color: @mainBackgroundColor;
+    color: @mainNavigationTextColor;
     cursor: pointer;
   }
 


### PR DESCRIPTION
Description:
This PR is to address issue  #391. Makes it so the locale and login buttons aren't using `@mainBackgroundColor` and use `@mainNavigationTextColor`

Linting:
- [x] No linting errors

Tests:
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests:
Change `@mainNavigationTextColor` and all the text on the header will change consistently. (icons are excluded)

Documentation:
- [ ] Requires documentation updates
