### PR TITLE
Point types to the proper index file

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.8",
   "main": "build/cjs/index",
   "main:src": "src/index",
-  "types": "build/src/index",
+  "types": "build/types/src/index.d.ts",
   "files": [
     "build/*"
   ],


### PR DESCRIPTION
Description:
<!--A brief description of changes. Things to include: WIP? Dependent PR's opened against other tickets? -->

This is a fix to point the package.json to the proper index.d.ts file in order for the types to be recognized by a client project.

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [ ] No linting errors

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [ ] Manual tests

delete the `src` in the components and just use the bundled js.  Notice that VS code will recognize the parameters that should be used for each component.

This is what it should look like
- [ ] Requires documentation updates
![Screen Shot 2019-09-06 at 12 13 51 PM](https://user-images.githubusercontent.com/25829859/64454443-d5642b80-d09f-11e9-9ef6-6a5e2e30e29a.png)

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->

