### PR TITLE
Consolidates color variables

### DIFF
--- a/app/src/containers/WriteReviewPage.less
+++ b/app/src/containers/WriteReviewPage.less
@@ -19,6 +19,8 @@
  *
  */
 
+ @import './../theme/common.less';
+
 .app-content {
   .pr-war {
     margin:0 auto;
@@ -45,7 +47,7 @@
       }
       &-review-count, &-write-review-link {
         font-size: 14px !important;
-        color: #40b1f3;
+        color: @firstComplimentColor;
       }
       &-rating-decimal {
         padding: 1px 6px;

--- a/app/src/theme/common.less
+++ b/app/src/theme/common.less
@@ -29,6 +29,9 @@
  @firstComplimentTextColor: #777777;
  
  @mainNavigationTextColor: #eee;
+
+ @buttonFocusColor: #007bff80;
+ @buttonActiveColor: #0062cc;
    
  @mainBorderColor: #d0d0d0;
  @firstBorderColor: #D4D3D3;

--- a/app/src/theme/style.less
+++ b/app/src/theme/style.less
@@ -197,11 +197,11 @@
    }
  
    &:focus {
-     outline: 2px solid #007bff80;
+     outline: 2px solid @buttonFocusColor;
    }
  
    &:active {
-     background-color: #0062cc;
+     background-color: @buttonActiveColor;
    }
  
    &:disabled {
@@ -225,11 +225,11 @@
      background-color: @firstComplimentColor;
  
      &:focus {
-       outline: 2px solid #007bff80;
+       outline: 2px solid @buttonFocusColor;
      }
  
      &:active {
-       background-color: #0062cc;
+       background-color: @buttonActiveColor;
      }
  
      &:disabled {

--- a/components/package-lock.json
+++ b/components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/store-components",
-  "version": "1.1.11",
+  "version": "1.1.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/store-components",
-  "version": "1.1.11",
+  "version": "1.1.14",
   "main": "build/cjs/index",
   "main:src": "src/index",
   "types": "src/index",

--- a/components/src/FeaturedProducts/featuredproducts.main.less
+++ b/components/src/FeaturedProducts/featuredproducts.main.less
@@ -83,7 +83,7 @@
         border-bottom-width: 2px;
         border-left-width: 2px;
         top: 6px;
-        color: #40B1F3;
+        color: @firstComplimentColor;
         opacity: 1;
       }
       &:hover {

--- a/components/src/GdprSupport/gdprsupport.main.less
+++ b/components/src/GdprSupport/gdprsupport.main.less
@@ -52,7 +52,7 @@
           top: 0;
           width: 9px;
           height: 15px;
-          border: solid #40b1f3;
+          border: solid @firstComplimentColor;
           border-width: 0 4px 4px 0;
           -webkit-transform: rotate(45deg);
           -ms-transform: rotate(45deg);

--- a/components/src/SearchFacetNavigation/searchfacetnavigation.main.less
+++ b/components/src/SearchFacetNavigation/searchfacetnavigation.main.less
@@ -36,7 +36,7 @@
 
       .card-title {
         .facet {
-          color: #40B1F3;
+          color: @firstComplimentColor;
           font-weight: 500;
           display: inline-block;
           width: 100%;
@@ -161,11 +161,11 @@
     padding: 0 10px;
     font-size: 14px;
     font-weight: 500;
-    color: #40B1F3;
+    color: @firstComplimentColor;
     border: 1px solid #EEEEEE;
     background-color: #F7F7F7;
     &:focus {
-      outline: 2px solid #007bff80;
+      outline: 2px solid @buttonFocusColor;
     }
 
     &-wrap {
@@ -182,7 +182,7 @@
       display: inline-block;
       width: 6px;
       height: 12px;
-      border: solid #40B1F3;
+      border: solid @firstComplimentColor;
       border-width: 0 2px 2px 0;
       -webkit-transform: rotate(45deg);
       -ms-transform: rotate(45deg);


### PR DESCRIPTION
Description:
<!--A brief description of changes. Things to include: WIP? Dependent PR's opened against other tickets? -->
- consolidates colors which already have variables and uses the variable instead of the color code value. (doesn't apply to glyphicons)
- adds color variables for button active and focus 

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Component Updates:
<!--Have you updated components/package.json and components/package-lock.json for any components that have been updated? -->
- [x] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests
- changing @firstComplimentColor value changes more components that use the same colors: featured products, facets, etc
- changing button active and focus color updates it for all buttons types.

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
