### PR TITLE
Added flex-wrap property to subcategory menu

### DIFF
--- a/components/package-lock.json
+++ b/components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/store-components",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/store-components",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "main": "build/cjs/index",
   "main:src": "src/index",
   "types": "src/index",

--- a/components/src/AppHeaderNavigation/appheadernavigation.main.less
+++ b/components/src/AppHeaderNavigation/appheadernavigation.main.less
@@ -36,6 +36,7 @@
       margin: 0;
       display: flex;
       flex-direction: row;
+      flex-wrap: wrap;
       justify-content: center;
       background-color: @mainBackgroundColor;
       .dropdown-item {


### PR DESCRIPTION
Description:
Currently, if there are too many sub-categories they extend beyond the page.  By adding the `flex-wrap: wrap` CSS property to the sub-category drop-down menu, the excess sub-category links wrap around into new lines

Linting:
- [x] No linting errors

Component Updates:
- [x] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests
I have an instance with set up with enough subcategories to trigger this case.  It is for a demo, so whoever is reviewing this connect with me over Slack and I can give them access details.

Alternatively, create a category with ~20 sub-categories in CM and navigate to the sub-categories through the storefront.

Documentation:
- [ ] Requires documentation updates
