### PR TITLE
add nginx resolver for /admin and /cortex proxy

### DIFF
--- a/docker/prod/nginx.conf
+++ b/docker/prod/nginx.conf
@@ -38,10 +38,12 @@ server {
     }
 
     location /admin {
+        resolver 127.0.0.11;
         proxy_pass       $AUTHSERVICE_URL;
     }
 
     location /cortex {
+        resolver 127.0.0.11;
         proxy_pass       $CORTEX_URL;
     }
 


### PR DESCRIPTION
Description:
On production environments, when the proxy is not available, the docker container for the storefront does not start up. docker container shows an error "host not found in upstream" and the docker container exits/stops. 

This means the storefront is not accessible because one or more components in not up and also creates an order dependency for deployments.

One possible solution is to use dockers internal DNS as the resolver; this solution should allow the storefront container to start up regardless of auth service or cortex being available. 


Linting:
<!--Have you validated that no linting errors are introduced? -->
- [X] No linting errors

Tests:
Because these are production dockers I haven't run these locally, to save time I figure it will be easier to to deploy this first and revert if it is not working. 

Documentation:
Not sure about this one, its possible a user may actually want the storefront to be not accessible with one or more services are not available? Maybe we will just need to add a reference to nginx documentation on resolvers? http://nginx.org/en/docs/http/ngx_http_core_module.html#resolver
