### PR TITLE
Request timeouts for Cortex and AM

### DIFF
--- a/app/src/ep.config.json
+++ b/app/src/ep.config.json
@@ -3,7 +3,7 @@
     "path": "/cortex",
     "scope": "vestri",
     "pathForProxy": "http://localhost:9080",
-    "reqTimeout": "10000"
+    "reqTimeout": "30000"
   },
   "supportedLocales": [
     {
@@ -36,7 +36,7 @@
     "authServiceAPI": {
       "path": "",
       "pathForProxy": "",
-      "reqTimeout": "10000"
+      "reqTimeout": "30000"
     },
     "keycloak": {
       "callbackUrl": "http://localhost:8080",

--- a/app/src/ep.config.json
+++ b/app/src/ep.config.json
@@ -2,7 +2,8 @@
   "cortexApi": {
     "path": "/cortex",
     "scope": "vestri",
-    "pathForProxy": "http://localhost:9080"
+    "pathForProxy": "http://localhost:9080",
+    "reqTimeout": "10000"
   },
   "supportedLocales": [
     {
@@ -34,7 +35,8 @@
     "dashboard": false,
     "authServiceAPI": {
       "path": "",
-      "pathForProxy": ""
+      "pathForProxy": "",
+      "reqTimeout": "10000"
     },
     "keycloak": {
       "callbackUrl": "http://localhost:8080",

--- a/app/src/utils/Cortex.ts
+++ b/app/src/utils/Cortex.ts
@@ -59,7 +59,7 @@ export function cortexFetch(input, init): any {
     queryFormat = `${queryCharacter}format=${standardlinks}${noself}${nodatalinks}`;
   }
 
-  return timeout(Config.cortexApi.reqTimeout || 30000, fetch(`${Config.cortexApi.path}${input}${queryFormat}`, requestInit)
+  return timeout((<any>Config).cortexApi.reqTimeout || 30000, fetch(`${Config.cortexApi.path}${input}${queryFormat}`, requestInit)
     .then((res) => {
       if ((res.status === 401 || res.status === 403) && input !== '/oauth2/tokens') {
         localStorage.removeItem(`${Config.cortexApi.scope}_oAuthRole`);
@@ -105,7 +105,7 @@ export function adminFetch(input, init): any {
     return mockFetch(input);
   }
 
-  return timeout(Config.b2b.authServiceAPI.reqTimeout || 30000, fetch(`${Config.b2b.authServiceAPI.path + input}`, requestInit)
+  return timeout((<any>Config).b2b.authServiceAPI.reqTimeout || 30000, fetch(`${Config.b2b.authServiceAPI.path + input}`, requestInit)
     .then((res) => {
       if ((res.status === 401 || res.status === 403) && input !== '/oauth2/tokens') {
         localStorage.removeItem(`${Config.cortexApi.scope}_oAuthRole`);

--- a/app/src/utils/Cortex.ts
+++ b/app/src/utils/Cortex.ts
@@ -59,7 +59,7 @@ export function cortexFetch(input, init): any {
     queryFormat = `${queryCharacter}format=${standardlinks}${noself}${nodatalinks}`;
   }
 
-  return timeout(Config.cortexApi.reqTimeout || 10000, fetch(`${Config.cortexApi.path}${input}${queryFormat}`, requestInit)
+  return timeout(Config.cortexApi.reqTimeout || 30000, fetch(`${Config.cortexApi.path}${input}${queryFormat}`, requestInit)
     .then((res) => {
       if ((res.status === 401 || res.status === 403) && input !== '/oauth2/tokens') {
         localStorage.removeItem(`${Config.cortexApi.scope}_oAuthRole`);
@@ -105,7 +105,7 @@ export function adminFetch(input, init): any {
     return mockFetch(input);
   }
 
-  return timeout(Config.b2b.authServiceAPI.reqTimeout || 10000, fetch(`${Config.b2b.authServiceAPI.path + input}`, requestInit)
+  return timeout(Config.b2b.authServiceAPI.reqTimeout || 30000, fetch(`${Config.b2b.authServiceAPI.path + input}`, requestInit)
     .then((res) => {
       if ((res.status === 401 || res.status === 403) && input !== '/oauth2/tokens') {
         localStorage.removeItem(`${Config.cortexApi.scope}_oAuthRole`);

--- a/app/src/utils/Cortex.ts
+++ b/app/src/utils/Cortex.ts
@@ -24,6 +24,15 @@ import mockFetch from './Mock';
 
 import * as Config from '../ep.config.json';
 
+export function timeout(ms, promise) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      reject();
+    }, ms);
+    promise.then(resolve, reject);
+  });
+}
+
 export function cortexFetch(input, init): any {
   const requestInit = init;
 
@@ -50,7 +59,7 @@ export function cortexFetch(input, init): any {
     queryFormat = `${queryCharacter}format=${standardlinks}${noself}${nodatalinks}`;
   }
 
-  return fetch(`${Config.cortexApi.path}${input}${queryFormat}`, requestInit)
+  return timeout(Config.cortexApi.reqTimeout || 10000, fetch(`${Config.cortexApi.path}${input}${queryFormat}`, requestInit)
     .then((res) => {
       if ((res.status === 401 || res.status === 403) && input !== '/oauth2/tokens') {
         localStorage.removeItem(`${Config.cortexApi.scope}_oAuthRole`);
@@ -76,6 +85,12 @@ export function cortexFetch(input, init): any {
     .catch((error) => {
       // eslint-disable-next-line no-console
       console.error(error.message);
+    }))
+    .catch((error) => {
+      if (window.location.href.indexOf('/maintenance') === -1) {
+        window.location.pathname = '/maintenance';
+      }
+      return new Response(new Blob(), {});
     });
 }
 
@@ -90,7 +105,7 @@ export function adminFetch(input, init): any {
     return mockFetch(input);
   }
 
-  return fetch(`${Config.b2b.authServiceAPI.path + input}`, requestInit)
+  return timeout(Config.b2b.authServiceAPI.reqTimeout || 10000, fetch(`${Config.b2b.authServiceAPI.path + input}`, requestInit)
     .then((res) => {
       if ((res.status === 401 || res.status === 403) && input !== '/oauth2/tokens') {
         localStorage.removeItem(`${Config.cortexApi.scope}_oAuthRole`);
@@ -113,5 +128,11 @@ export function adminFetch(input, init): any {
     .catch((error) => {
       // eslint-disable-next-line no-console
       console.error(error.message);
+    }))
+    .catch((error) => {
+      if (window.location.href.indexOf('/maintenance') === -1) {
+        window.location.pathname = '/maintenance';
+      }
+      return new Response(new Blob(), {});
     });
 }

--- a/app/src/utils/Cortex.ts
+++ b/app/src/utils/Cortex.ts
@@ -86,7 +86,7 @@ export function cortexFetch(input, init): any {
       // eslint-disable-next-line no-console
       console.error(error.message);
     }))
-    .catch((error) => {
+    .catch(() => {
       if (window.location.href.indexOf('/maintenance') === -1) {
         window.location.pathname = '/maintenance';
       }
@@ -129,7 +129,7 @@ export function adminFetch(input, init): any {
       // eslint-disable-next-line no-console
       console.error(error.message);
     }))
-    .catch((error) => {
+    .catch(() => {
       if (window.location.href.indexOf('/maintenance') === -1) {
         window.location.pathname = '/maintenance';
       }

--- a/components/src/utils/ConfigProvider.ts
+++ b/components/src/utils/ConfigProvider.ts
@@ -25,7 +25,8 @@ export interface IEpConfig {
   cortexApi: {
     path: string,
     scope: string,
-    pathForProxy: string
+    pathForProxy: string,
+    reqTimeout: string
   },
   supportedLocales: Array<{
     value: string,
@@ -44,7 +45,8 @@ export interface IEpConfig {
     enable: boolean,
     authServiceAPI: {
       path: string,
-      pathForProxy: string
+      pathForProxy: string,
+      reqTimeout: string
     },
     keycloak: {
       callbackUrl: string,

--- a/components/src/utils/Cortex.js
+++ b/components/src/utils/Cortex.js
@@ -24,12 +24,12 @@ import mockFetch from './Mock';
 import { getConfig } from './ConfigProvider';
 
 export function timeout(ms, promise) {
-  return new Promise(function (resolve, reject) {
-    setTimeout(function () {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
       reject();
-    }, ms)
-    promise.then(resolve, reject)
-  })
+    }, ms);
+    promise.then(resolve, reject);
+  });
 }
 
 export function cortexFetch(input, init) {
@@ -76,7 +76,8 @@ export function cortexFetch(input, init) {
     .catch((error) => {
       // eslint-disable-next-line no-console
       console.error(error.message);
-    })).catch(function (error) {
+    }))
+    .catch((error) => {
       if (window.location.href.indexOf('/maintenance') === -1) {
         window.location.pathname = '/maintenance';
       }
@@ -120,7 +121,8 @@ export function adminFetch(input, init) {
     .catch((error) => {
       // eslint-disable-next-line no-console
       console.error(error.message);
-    })).catch(function (error) {
+    }))
+    .catch((error) => {
       if (window.location.href.indexOf('/maintenance') === -1) {
         window.location.pathname = '/maintenance';
       }

--- a/components/src/utils/Cortex.js
+++ b/components/src/utils/Cortex.js
@@ -50,7 +50,7 @@ export function cortexFetch(input, init) {
     return mockFetch(input, requestInit);
   }
 
-  return timeout(Config.cortexApi.reqTimeout || 10000, fetch(`${Config.cortexApi.path + input}`, requestInit)
+  return timeout(Config.cortexApi.reqTimeout || 30000, fetch(`${Config.cortexApi.path + input}`, requestInit)
     .then((res) => {
       if ((res.status === 401 || res.status === 403) && input != '/oauth2/tokens') {
         localStorage.removeItem(`${Config.cortexApi.scope}_oAuthRole`);
@@ -97,7 +97,7 @@ export function adminFetch(input, init) {
     return mockFetch(input, requestInit);
   }
 
-  return timeout(Config.b2b.authServiceAPI.reqTimeout || 10000, fetch(`${Config.b2b.authServiceAPI.path + input}`, requestInit)
+  return timeout(Config.b2b.authServiceAPI.reqTimeout || 30000, fetch(`${Config.b2b.authServiceAPI.path + input}`, requestInit)
     .then((res) => {
       if (res.status === 401 || res.status === 403) {
         localStorage.removeItem(`${Config.cortexApi.scope}_oAuthRole`);

--- a/components/src/utils/Cortex.js
+++ b/components/src/utils/Cortex.js
@@ -77,7 +77,7 @@ export function cortexFetch(input, init) {
       // eslint-disable-next-line no-console
       console.error(error.message);
     }))
-    .catch((error) => {
+    .catch(() => {
       if (window.location.href.indexOf('/maintenance') === -1) {
         window.location.pathname = '/maintenance';
       }
@@ -122,7 +122,7 @@ export function adminFetch(input, init) {
       // eslint-disable-next-line no-console
       console.error(error.message);
     }))
-    .catch((error) => {
+    .catch(() => {
       if (window.location.href.indexOf('/maintenance') === -1) {
         window.location.pathname = '/maintenance';
       }


### PR DESCRIPTION
Description:
<!--A brief description of changes. Things to include: WIP? Dependent PR's opened against other tickets? -->
- Surround cortexFetch and adminFetch fetch requests with timeout.

Timeout can be configured in ep.config.json for both Cortex, and AM. Default in code set to 10s, and can be overridden via config.

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Component Updates:
<!--Have you updated components/package.json and components/package-lock.json for any components that have been updated? -->
- [x] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [x] E2E tests (npm test run with `e2e`)
- [x] Manual tests

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [x] Requires documentation updates
