### PR TITLE
Dynamic bundle enhancements

### DIFF
--- a/components/package-lock.json
+++ b/components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/store-components",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/store-components",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "main": "build/cjs/index",
   "main:src": "src/index",
   "types": "src/index",

--- a/components/src/AppModalBundleConfiguration/appmodalbundleconfiguration.main.tsx
+++ b/components/src/AppModalBundleConfiguration/appmodalbundleconfiguration.main.tsx
@@ -105,9 +105,7 @@ class AppModalBundleConfigurationMain extends React.Component<AppModalBundleConf
 
   componentDidUpdate(prevProps) {
     const { bundleConfigurationItems } = this.props;
-    if (JSON.stringify(bundleConfigurationItems) !== JSON.stringify(prevProps.bundleConfigurationItems)) {
-      this.fetchDependantItemData(bundleConfigurationItems);
-    }
+    this.fetchDependantItemData(bundleConfigurationItems);
   }
 
   fetchDependantItemData(bundleConfigurationItems) {

--- a/components/src/AppModalBundleConfiguration/appmodalbundleconfiguration.main.tsx
+++ b/components/src/AppModalBundleConfiguration/appmodalbundleconfiguration.main.tsx
@@ -216,6 +216,7 @@ class AppModalBundleConfigurationMain extends React.Component<AppModalBundleConf
                         onRemove={this.handleRemove}
                         onConfiguratorAddToCart={this.handleConfiguratorAddToCart}
                         onMoveToCart={this.handleMoveToCart}
+                        itemDetailLink={itemDetailLink}
                       />
                     ))}
                   </div>

--- a/components/src/CartLineItem/cart.lineitem.tsx
+++ b/components/src/CartLineItem/cart.lineitem.tsx
@@ -527,7 +527,7 @@ class CartLineItem extends React.Component<CartLineItemProps, CartLineItemState>
           </div>
         ) : ('')
         }
-        {(item._dependentoptions && item._dependentoptions[0] && (item._dependentoptions[0]._element || item._dependentlineitems[0]._element)) ? (
+        {((item._dependentoptions && item._dependentoptions[0] && item._dependentoptions[0]._element) || (item._dependentlineitems && item._dependentlineitems[0] && item._dependentlineitems[0]._element)) ? (
           <div className="configure-btn-col">
             <button className="ep-btn primary small btn-cart-configureBundle" type="button" onClick={() => this.handleModalOpen()}>
               <span className="btn-text">


### PR DESCRIPTION
Description:
Some small improvements focused on the Dynamic Bundle configurator:
 - The link to the PDP for Available Products in a bundle now is properly formed
 - Adding or removing nested constituents with a 0.00 cost will now trigger a new call to update nested bundles.
 - Including dynamic bundles underneath static bundles now allows them to be configured.  Prior to this static bundles would prevent the configurator from opening and allowing a user to configure their nested bundles

Linting:
- [x] No linting errors

Component Updates:
- [x] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests
You will need an instance with the Dynamic Bundle accelerator to test this.
1) Click on the PDP link from an Available Product in the dynamic bundle configurator - this will take you to the PDP now instead of returning a 404
2) Create a nested dynamic bundle with a $0.00 cost constituent.  Adding or removing that constituent from the nested bundle should now trigger a call to retrieve the updated constituents of the bundle
3) Create a top level static bundle that contains a nested bundle.  The Configure button will now appear and let you reach the nested dynamic bundle.
 

Documentation:
- [ ] Requires documentation updates
