### PR TITLE
[Closes #446] Quick Order Form now allows multi-sku products

### DIFF
--- a/components/package-lock.json
+++ b/components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/store-components",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/store-components",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "main": "build/cjs/index",
   "main:src": "src/index",
   "types": "src/index",

--- a/components/src/QuickOrderForm/quickorderform.tsx
+++ b/components/src/QuickOrderForm/quickorderform.tsx
@@ -87,11 +87,16 @@ class QuickOrderForm extends React.Component<QuickOrderFormProps, QuickOrderForm
 
   setItemData(item, quantity, code) {
     const { onItemSubmit } = this.props;
-    if (item._definition[0]._options) {
+    if (item._availability[0].state !== 'AVAILABLE') {
       this.setState({
         code,
         product: item,
-        skuErrorMessage: intl.get('configurable-product-message', { SKUCode: code }),
+        skuErrorMessage: `${intl.get('not-available-message')}`,
+      });
+    } else if (!item._price) {
+      this.setState({
+        code,
+        skuErrorMessage: `${intl.get('product-message-without-price', { SKUCode: code })}`,
       });
     } else {
       this.setState({
@@ -100,19 +105,6 @@ class QuickOrderForm extends React.Component<QuickOrderFormProps, QuickOrderForm
         code,
       });
       onItemSubmit({ isValidField: true });
-    }
-    if (item._availability[0].state !== 'AVAILABLE') {
-      this.setState({
-        code,
-        product: item,
-        skuErrorMessage: `${intl.get('not-available-message')}`,
-      });
-    }
-    if (!item._price) {
-      this.setState({
-        code,
-        skuErrorMessage: `${intl.get('product-message-without-price', { SKUCode: code })}`,
-      });
     }
   }
 
@@ -123,11 +115,18 @@ class QuickOrderForm extends React.Component<QuickOrderFormProps, QuickOrderForm
       cortexFetchItemLookupForm()
         .then(() => itemLookup(productId, false)
           .then((res) => {
-            if (res._definition[0]._options) {
+            if (res._availability[0].state !== 'AVAILABLE') {
               this.setState({
                 product: res,
                 isLoading: false,
-                skuErrorMessage: intl.get('configurable-product-message', { SKUCode: productId }),
+                skuErrorMessage: `${intl.get('not-available-message')}`,
+              });
+              onItemSubmit({
+                code, quantity, product: {}, isValidField: false,
+              });
+            } else if (!res._price) {
+              this.setState({
+                skuErrorMessage: `${intl.get('product-message-without-price', { SKUCode: productId })}`,
               });
               onItemSubmit({
                 code, quantity, product: {}, isValidField: false,
@@ -143,24 +142,6 @@ class QuickOrderForm extends React.Component<QuickOrderFormProps, QuickOrderForm
                 skuErrorMessage: '',
                 product: res,
                 isLoading: false,
-              });
-            }
-            if (res._availability[0].state !== 'AVAILABLE') {
-              this.setState({
-                product: res,
-                isLoading: false,
-                skuErrorMessage: `${intl.get('not-available-message')}`,
-              });
-              onItemSubmit({
-                code, quantity, product: {}, isValidField: false,
-              });
-            }
-            if (!res._price) {
-              this.setState({
-                skuErrorMessage: `${intl.get('product-message-without-price', { SKUCode: productId })}`,
-              });
-              onItemSubmit({
-                code, quantity, product: {}, isValidField: false,
               });
             }
           })


### PR DESCRIPTION
Description:

Addresses https://github.com/elasticpath/react-pwa-reference-storefront/issues/446

It should be noted that I did not add a check to see if there are cart item modifiers.  I think if we do that we will be implementing business logic in the front-end unnecessarily.

Linting:
- [x] No linting errors

Component Updates:
- [x] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
- [x] E2E tests (npm test run with `e2e`)
- [x] Manual tests
I added multi-sku products to the cart using the quick order form

Documentation:
- [ ] Requires documentation updates
