### PR TITLE
Fixed subaccount tree control in admin dashboard

### DIFF
--- a/app/src/containers/b2b/AccountMain.tsx
+++ b/app/src/containers/b2b/AccountMain.tsx
@@ -322,6 +322,14 @@ export default class AccountMain extends React.Component<RouteComponentProps<Acc
               </div>
             </div>
             <div className="account-component">
+              <AccountList
+                getAccountData={this.getAccountData}
+                accountListData={accountListData}
+                getSubAccountData={this.subAccountData}
+                handleAddSubAccountClicked={this.handleAddSubAccountClicked}
+                accountName={accountName}
+                registrationNumber={registrationNumber}
+              />
               <div className="associates-container">
                 <div className="add-associate-container">
                   <button type="button" className="ep-btn primary small add-associate-button" onClick={() => this.handleAddAssociateClicked()}>

--- a/app/src/containers/b2b/SubAccountListItem.tsx
+++ b/app/src/containers/b2b/SubAccountListItem.tsx
@@ -41,7 +41,6 @@ interface SubAccountListState {
     subAccountData: any,
     isLoading: boolean,
     subAccountOpened: boolean,
-    accountName: string,
     highlight: boolean,
 }
 
@@ -101,7 +100,6 @@ export default class SubAccountListItem extends React.Component<SubAccountListPr
       subAccountData: {},
       isLoading: false,
       subAccountOpened: false,
-      accountName: '',
       highlight: false,
     };
 
@@ -183,14 +181,14 @@ export default class SubAccountListItem extends React.Component<SubAccountListPr
                 <div className="loader" />
               </div>
             ) : (accountData._subaccounts && accountData._subaccounts[0]._element && (
-            // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-            <span
-              className={`arrow-btn ${subAccountOpened ? 'up' : ''}`}
-              onClick={event => this.getSubAccounts(accountData.self.uri, event)}
-              onKeyPress={event => this.getSubAccounts(accountData.self.uri, event)}
-            />
+              // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+              <span
+                className={`arrow-btn ${subAccountOpened ? 'up' : ''}`}
+                onClick={event => this.getSubAccounts(accountData.self.uri, event)}
+                onKeyPress={event => this.getSubAccounts(accountData.self.uri, event)}
+              />
             ))
-                    }
+          }
           <span className="status">
             <i className={`icons-status ${accountData._statusinfo[0]._status[0].status.toLowerCase()}`} />
             {intl.get(accountData._statusinfo[0]._status[0].status.toLowerCase())}


### PR DESCRIPTION
Description:
Reintroduced `AccountList` component that accidentally got removed during TypeScript build fix.

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Component Updates:
<!--Have you updated components/package.json and components/package-lock.json for any components that have been updated? -->
- [ ] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [ ] Manual tests

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
