### PR TITLE
Fixed browser reload when navigating to account

### DIFF
--- a/app/src/containers/b2b/Dashboard.tsx
+++ b/app/src/containers/b2b/Dashboard.tsx
@@ -22,7 +22,7 @@
 
 import React from 'react';
 import intl from 'react-intl-universal';
-import { Link } from 'react-router-dom';
+import { Link, RouteComponentProps } from 'react-router-dom';
 import { adminFetch } from '../../utils/Cortex';
 import { login } from '../../utils/AuthService';
 import { ReactComponent as AccountIcon } from '../../images/header-icons/account-icon.svg';
@@ -62,7 +62,7 @@ const accountsZoomArray = [
   'accounts:element:associateroleassignments:element:associate:primaryemail',
 ];
 
-export default class Dashboard extends React.Component<{}, DashboardState> {
+export default class Dashboard extends React.Component<RouteComponentProps, DashboardState> {
   constructor(props) {
     super(props);
     this.state = {
@@ -242,6 +242,10 @@ export default class Dashboard extends React.Component<{}, DashboardState> {
     }
   }
 
+  handleAccountClicked(account: any) {
+    const { history } = this.props;
+    history.push(`/b2b/account/${account.uri}`);
+  }
 
   render() {
     const {
@@ -397,7 +401,7 @@ export default class Dashboard extends React.Component<{}, DashboardState> {
                     </thead>
                     <tbody>
                       {accounts.map(account => (
-                        <tr key={account.uri} onClick={() => { window.location.href = `/b2b/account/${account.uri}`; }} className="account-list-rows">
+                        <tr key={account.uri} onClick={() => this.handleAccountClicked(account)} className="account-list-rows">
                           <td className="name">{account.name}</td>
                           <td className="external-id">{account.externalId}</td>
                           <td className="status">


### PR DESCRIPTION
Description:
This PR fixes the issue with browser reloading when a user clicks on an account in admin dashboard. As a side effect, because of the reload, this was causing "shop for" dialog to appear every time a user would click on an account.

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Component Updates:
<!--Have you updated components/package.json and components/package-lock.json for any components that have been updated? -->
- [ ] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [ ] Manual tests

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
