### PR TITLE
[PB-5819] Buyer Admins should not see data that only Seller Admins sh…

### DIFF
--- a/app/src/containers/b2b/AccountMain.tsx
+++ b/app/src/containers/b2b/AccountMain.tsx
@@ -34,11 +34,13 @@ import * as Config from '../../ep.config.json';
 import './AccountMain.less';
 
 const accountZoomArray = [
+  'accountmetadata',
   'selfsignupinfo',
   'statusinfo',
   'statusinfo:status',
   'subaccounts',
   'subaccounts:element',
+  'subaccounts:element:accountmetadata',
   'subaccounts:element:subaccounts',
   'subaccounts:element:subaccounts:element',
   'subaccounts:element:statusinfo',
@@ -108,7 +110,9 @@ interface AccountMainState {
   isAddAssociateOpen: boolean,
   addAssociateUri: string,
   addSubAccountUri: string,
+  addSubAccountSellerAdmin: boolean,
   editSubAccountUri: string,
+  editMetadataUri: string,
   subAccounts: any,
 }
 
@@ -139,7 +143,9 @@ export default class AccountMain extends React.Component<RouteComponentProps<Acc
       associateEditEmail: '',
       addAssociateUri: '',
       addSubAccountUri: '',
+      addSubAccountSellerAdmin: false,
       editSubAccountUri: '',
+      editMetadataUri: '',
       subAccounts: {},
     };
 
@@ -186,17 +192,19 @@ export default class AccountMain extends React.Component<RouteComponentProps<Acc
           this.setState({
             accountName: accounts.name,
             mainAccountName: accounts.name,
-            externalId: accounts['external-id'],
+            externalId: accounts._accountmetadata ? accounts._accountmetadata[0]['external-id'] : null,
             registrationNumber: accounts['registration-id'],
             isLoading: false,
             legalName: accounts['legal-name'],
             associates: accounts._associateroleassignments[0]._element ? accounts._associateroleassignments[0]._element.map(element => ({ associate: element._associate[0], roles: element._roleinfo[0] })) : [],
             status: accounts._statusinfo[0]._status[0].status,
             editSubAccountUri: accounts.self.uri,
+            editMetadataUri: accounts._accountmetadata ? accounts._accountmetadata[0].self.uri : null,
             selfSignUpCode: accounts._selfsignupinfo ? accounts._selfsignupinfo[0]['self-signup-code'] : '',
             userEmail: profile._myprofile[0]._primaryemail[0].email,
             addAssociateUri: accounts._associateroleassignments[0]._associateform[0]._addassociateaction[0].self.uri,
             addSubAccountUri: accounts._subaccounts[0]._accountform[0].self.uri,
+            addSubAccountSellerAdmin: typeof accounts._subaccounts[0]._accountform[0]['external-id'] !== 'undefined',
             subAccounts: accounts._subaccounts[0],
           });
         })
@@ -212,13 +220,15 @@ export default class AccountMain extends React.Component<RouteComponentProps<Acc
   subAccountData(data) {
     this.setState({
       accountName: data.name,
-      externalId: data['external-id'],
+      externalId: data._accountmetadata ? data._accountmetadata[0]['external-id'] : null,
       registrationNumber: data['registration-id'],
       legalName: data['legal-name'],
       associates: data._associateroleassignments[0]._element ? data._associateroleassignments[0]._element.map(element => ({ associate: element._associate[0], roles: element._roleinfo[0] })) : [],
       addAssociateUri: data._associateroleassignments[0]._associateform[0]._addassociateaction[0].self.uri,
       addSubAccountUri: data._subaccounts[0]._accountform[0].self.uri,
+      addSubAccountSellerAdmin: typeof data._subaccounts[0]._accountform[0]['external-id'] !== 'undefined',
       editSubAccountUri: data.self.uri,
+      editMetadataUri: data._accountmetadata ? data._accountmetadata[0].self.uri : null,
     });
   }
 
@@ -270,7 +280,9 @@ export default class AccountMain extends React.Component<RouteComponentProps<Acc
       userEmail,
       addAssociateUri,
       addSubAccountUri,
+      addSubAccountSellerAdmin,
       editSubAccountUri,
+      editMetadataUri,
       isAddAssociateOpen,
       subAccounts,
       mainAccountName,
@@ -386,6 +398,7 @@ export default class AccountMain extends React.Component<RouteComponentProps<Acc
                 isOpen={isSettingsDialogOpen}
                 accountData={editAccountData}
                 editSubAccountUri={editSubAccountUri}
+                editMetadataUri={editMetadataUri}
               />
               <EditAssociate
                 handleClose={this.isEditAssociateClose}
@@ -404,6 +417,7 @@ export default class AccountMain extends React.Component<RouteComponentProps<Acc
                 handleUpdate={this.handleAccountSettingsUpdate}
                 isOpen={isAddSubAccountOpen}
                 addSubAccountUri={addSubAccountUri}
+                addSubAccountSellerAdmin={addSubAccountSellerAdmin}
               />
             </div>
           </div>

--- a/app/src/containers/b2b/AddSubAccount.tsx
+++ b/app/src/containers/b2b/AddSubAccount.tsx
@@ -34,6 +34,7 @@ interface AddSubAccountProps {
     handleClose: () => void,
     handleUpdate: () => void,
     addSubAccountUri: string,
+    addSubAccountSellerAdmin: boolean,
 }
 
 interface AddSubAccountState {
@@ -101,11 +102,12 @@ export default class AddSubAccount extends React.Component<AddSubAccountProps, A
     const { name } = event.target;
     const { value } = event.target;
 
-    this.setState({ name: value });
+    // @ts-ignore
+    this.setState({ [name]: value });
   }
 
   render() {
-    const { isOpen, handleClose } = this.props;
+    const { isOpen, handleClose, addSubAccountSellerAdmin } = this.props;
     const {
       name, legalName, externalId, registrationNumber, isLoading,
     } = this.state;
@@ -130,14 +132,16 @@ export default class AddSubAccount extends React.Component<AddSubAccountProps, A
               </label>
             </div>
             <div className="b2b-form-row">
-              <label htmlFor="external-id" className="b2b-form-col">
-                <p className="b2b-dark-text">{intl.get('external-id')}</p>
-                <input id="external-id" className="b2b-input" value={externalId || ''} onChange={this.changeHandler} name="externalId" type="text" />
-              </label>
               <label htmlFor="registration-number" className="b2b-form-col">
                 <p className="b2b-dark-text">{intl.get('registration-number')}</p>
                 <input id="registration-number" className="b2b-input" value={registrationNumber || ''} onChange={this.changeHandler} name="registrationNumber" type="text" />
               </label>
+              {addSubAccountSellerAdmin && (
+                <label htmlFor="external-id" className="b2b-form-col">
+                  <p className="b2b-dark-text">{intl.get('external-id')}</p>
+                  <input id="external-id" className="b2b-input" value={externalId || ''} onChange={this.changeHandler} name="externalId" type="text" />
+                </label>)
+              }
             </div>
           </form>
         </div>

--- a/app/src/containers/b2b/Dashboard.tsx
+++ b/app/src/containers/b2b/Dashboard.tsx
@@ -40,11 +40,13 @@ interface DashboardState {
   isLoading: boolean,
   showSearchLoader: boolean,
   noSearchResults: boolean,
+  isSellerAdmin: boolean,
 }
 
 const accountsZoomArray = [
   'accounts',
   'accounts:element',
+  'accounts:element:accountmetadata',
   'accounts:element:selfsignupinfo',
   'accounts:element:statusinfo',
   'accounts:element:statusinfo:status',
@@ -118,6 +120,7 @@ export default class Dashboard extends React.Component<RouteComponentProps, Dash
       accounts: [],
       admins: [],
       searchAccounts: '',
+      isSellerAdmin: false,
     };
     this.getAdminData();
     this.setSearchAccounts = this.setSearchAccounts.bind(this);
@@ -144,11 +147,15 @@ export default class Dashboard extends React.Component<RouteComponentProps, Dash
               const uri = account.self.uri.split('/').pop();
               return {
                 name: account.name,
-                externalId: account['external-id'],
+                externalId: account._accountmetadata ? account._accountmetadata[0]['external-id'] : null,
                 status: account._statusinfo[0]._status[0].status.toLowerCase(),
                 uri,
               };
             });
+            let isSellerAdmin = false;
+            if (res._accounts[0]._element[0]._accountmetadata) {
+              isSellerAdmin = true;
+            }
             const map = new Map();
             res._accounts[0]._element.reduce((accum, account) => {
               const associates = account._associateroleassignments[0]._element;
@@ -166,7 +173,7 @@ export default class Dashboard extends React.Component<RouteComponentProps, Dash
             const admins = Array.from(map.values());
 
             this.setState({
-              accounts, admins, isLoading: false, noSearchResults: false,
+              accounts, admins, isLoading: false, noSearchResults: false, isSellerAdmin,
             });
           }
         });
@@ -209,12 +216,21 @@ export default class Dashboard extends React.Component<RouteComponentProps, Dash
                       const uri = account.self.uri.split('/').pop();
                       return {
                         name: account.name,
-                        externalId: account['external-id'],
+                        externalId: account._accountmetadata[0]['external-id'],
                         status: account._statusinfo[0]._status[0].status.toLowerCase(),
                         uri,
                       };
                     });
-                    this.setState({ accounts, showSearchLoader: false, noSearchResults: false });
+                    let isSellerAdmin = false;
+                    if (res._accounts[0]._element[0]._accountmetadata) {
+                      isSellerAdmin = true;
+                    }
+                    this.setState({
+                      accounts,
+                      showSearchLoader: false,
+                      noSearchResults: false,
+                      isSellerAdmin,
+                    });
                   } else {
                     this.setState({ showSearchLoader: false, noSearchResults: true });
                   }
@@ -258,6 +274,7 @@ export default class Dashboard extends React.Component<RouteComponentProps, Dash
       searchAccounts,
       showSearchLoader,
       noSearchResults,
+      isSellerAdmin,
     } = this.state;
 
     return (
@@ -387,14 +404,16 @@ export default class Dashboard extends React.Component<RouteComponentProps, Dash
                       <tr>
                         <th className="name">
                           {intl.get('name')}
-                          <span className="mobile-table-title">
-                            {' '}
-                            &
-                            {' '}
-                            {intl.get('external-id')}
-                          </span>
+                          {isSellerAdmin && (
+                            <span className="mobile-table-title">
+                              {' '}
+                              &
+                              {' '}
+                              {intl.get('external-id')}
+                            </span>)
+                           }
                         </th>
-                        <th className="external-id">{intl.get('external-id')}</th>
+                        {isSellerAdmin && <th className="external-id">{intl.get('external-id')}</th>}
                         <th className="status">{intl.get('status')}</th>
                         <th className="arrow" />
                       </tr>
@@ -403,7 +422,7 @@ export default class Dashboard extends React.Component<RouteComponentProps, Dash
                       {accounts.map(account => (
                         <tr key={account.uri} onClick={() => this.handleAccountClicked(account)} className="account-list-rows">
                           <td className="name">{account.name}</td>
-                          <td className="external-id">{account.externalId}</td>
+                          {isSellerAdmin && <td className="external-id">{account.externalId}</td>}
                           <td className="status">
                             <i className={`icons-status ${account.status.toLowerCase()}`} />
                             {intl.get(account.status)}

--- a/app/src/containers/b2b/EditAccount.less
+++ b/app/src/containers/b2b/EditAccount.less
@@ -46,7 +46,7 @@
         width: 100%;
         padding: 0;
       }
-      &:last-child {
+      &:last-child:not(:only-child) {
         padding-right: 0;
         padding-left: 20px;
 

--- a/app/src/containers/b2b/EditAccount.tsx
+++ b/app/src/containers/b2b/EditAccount.tsx
@@ -36,6 +36,7 @@ const COPIED_TIMEOUT_LENGTH = 4000;
 interface EditAccountProps {
   isOpen: boolean,
   editSubAccountUri: string,
+  editMetadataUri: string,
   handleClose: () => void,
   handleUpdate: () => void,
   accountData: {
@@ -95,7 +96,9 @@ export default class EditAccount extends React.Component<EditAccountProps, EditA
   }
 
   editAccount(event) {
-    const { handleClose, handleUpdate, editSubAccountUri } = this.props;
+    const {
+      handleClose, handleUpdate, editSubAccountUri, editMetadataUri,
+    } = this.props;
     const {
       name, legalName, externalId, registrationNumber,
     } = this.state;
@@ -111,11 +114,24 @@ export default class EditAccount extends React.Component<EditAccountProps, EditA
         },
         body: JSON.stringify({
           name,
-          'external-id': externalId,
           'legal-name': legalName,
           'registration-id': registrationNumber,
         }),
       })
+        .then(() => {
+          if (editMetadataUri) {
+            adminFetch(`${editMetadataUri}`, {
+              method: 'put',
+              headers: {
+                'Content-Type': 'application/json',
+                Authorization: localStorage.getItem(`${Config.cortexApi.scope}_oAuthTokenAuthService`),
+              },
+              body: JSON.stringify({
+                'external-id': externalId,
+              }),
+            });
+          }
+        })
         .then(() => {
           handleClose();
           handleUpdate();
@@ -147,7 +163,9 @@ export default class EditAccount extends React.Component<EditAccountProps, EditA
   }
 
   render() {
-    const { isOpen, handleClose, accountData } = this.props;
+    const {
+      isOpen, handleClose, accountData, editMetadataUri,
+    } = this.props;
     const {
       name, legalName, externalId, registrationNumber, isShowingCopied, isLoading,
     } = this.state;
@@ -172,14 +190,16 @@ export default class EditAccount extends React.Component<EditAccountProps, EditA
               </label>
             </div>
             <div className="b2b-form-row">
-              <label htmlFor="external-id" className="b2b-form-col">
-                <p className="b2b-dark-text">{intl.get('external-id')}</p>
-                <input id="external-id" className="b2b-input" value={externalId || ''} onChange={this.changeHandler} name="externalId" type="text" />
-              </label>
               <label htmlFor="registration-number" className="b2b-form-col">
                 <p className="b2b-dark-text">{intl.get('registration-number')}</p>
                 <input id="registration-number" className="b2b-input" value={registrationNumber || ''} onChange={this.changeHandler} name="registrationNumber" type="text" />
               </label>
+              {editMetadataUri && (
+                <label htmlFor="external-id" className="b2b-form-col">
+                  <p className="b2b-dark-text">{intl.get('external-id')}</p>
+                  <input id="external-id" className="b2b-input" value={externalId || ''} onChange={this.changeHandler} name="externalId" type="text" />
+                </label>)
+              }
             </div>
             {accountData.selfSignUpCode && (
               <div className="b2b-form-row">


### PR DESCRIPTION
…ould see

There were some changes to the apis for the Admin dashboard, this pr makes it so that only Seller Admins see external-id.

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Component Updates:
<!--Have you updated components/package.json and components/package-lock.json for any components that have been updated? -->
- [ ] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests
I've tested the scenarios for the dashboard that use external-id, anything that I've modified.

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
