### PR TITLE
Fix for Cart Page with Dynamic Bundles

### DIFF
--- a/app/src/containers/CartPage.less
+++ b/app/src/containers/CartPage.less
@@ -209,7 +209,7 @@
     margin-bottom: 10px;
   }
 
-  .btn-cmd-checkout, .btn-add-promotion, .btn-cart-removelineitem {
+  .btn-cmd-checkout, .btn-add-promotion, .btn-cart-removelineitem, .btn-cart-configureBundle {
     text-transform: none;
   }
 

--- a/app/src/containers/CartPage.less
+++ b/app/src/containers/CartPage.less
@@ -231,10 +231,5 @@
         margin: 0;
       }
     }
-
-    .remove-btn-col {
-      display: inline-block;
-      float: right;
-    }
   }
 }

--- a/components/package-lock.json
+++ b/components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/store-components",
-  "version": "1.1.21",
+  "version": "1.1.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/store-components",
-  "version": "1.1.21",
+  "version": "1.1.22",
   "main": "build/cjs/index",
   "main:src": "src/index",
   "types": "src/index",

--- a/components/src/AppModalBundleConfiguration/appmodalbundleconfiguration.main.tsx
+++ b/components/src/AppModalBundleConfiguration/appmodalbundleconfiguration.main.tsx
@@ -102,12 +102,6 @@ class AppModalBundleConfigurationMain extends React.Component<AppModalBundleConf
     this.fetchDependantItemData(bundleConfigurationItems);
   }
 
-
-  componentDidUpdate(prevProps) {
-    const { bundleConfigurationItems } = this.props;
-    this.fetchDependantItemData(bundleConfigurationItems);
-  }
-
   fetchDependantItemData(bundleConfigurationItems) {
     login().then(() => {
       cortexFetch(`${bundleConfigurationItems.self.uri}/?zoom=${zoomArray.sort().join()}`, {
@@ -145,17 +139,29 @@ class AppModalBundleConfigurationMain extends React.Component<AppModalBundleConf
   }
 
   handleConfiguratorAddToCart() {
-    const { onItemConfiguratorAddToCart } = this.props;
+    const {
+      onItemConfiguratorAddToCart,
+      bundleConfigurationItems,
+    } = this.props;
+    this.fetchDependantItemData(bundleConfigurationItems);
     onItemConfiguratorAddToCart();
   }
 
   handleMoveToCart() {
-    const { onItemMoveToCart } = this.props;
+    const {
+      onItemMoveToCart,
+      bundleConfigurationItems,
+    } = this.props;
+    this.fetchDependantItemData(bundleConfigurationItems);
     onItemMoveToCart();
   }
 
   handleRemove() {
-    const { onItemRemove } = this.props;
+    const {
+      onItemRemove,
+      bundleConfigurationItems,
+    } = this.props;
+    this.fetchDependantItemData(bundleConfigurationItems);
     onItemRemove();
   }
 

--- a/components/src/CartLineItem/cart.lineitem.less
+++ b/components/src/CartLineItem/cart.lineitem.less
@@ -263,5 +263,11 @@
     .configure-btn-col {
       grid-column: 1;
     }
+
+    .remove-btn-col,
+    .configure-btn-col,
+    .move-to-cart-btn-col {
+      float: right;
+    }
   }
 }

--- a/components/src/CartLineItem/cart.lineitem.less
+++ b/components/src/CartLineItem/cart.lineitem.less
@@ -116,7 +116,7 @@
   }
 
   .unit-total-price-col {
-    grid-row: 1 / span 3;
+    grid-row: 1 / span 2;
     .unit-price-col {
       text-align: right;
       .cart-unit-list-price {
@@ -142,6 +142,15 @@
     .ep-btn {
       margin: 0;
     }
+  }
+
+  .remove-btn-col {
+    grid-row: 4;
+  }
+
+  .move-to-cart-btn-col,
+  .configure-btn-col {
+    grid-row: 3;
   }
 
   th:last-child,


### PR DESCRIPTION
Description:
<!--A brief description of changes. Things to include: WIP? Dependent PR's opened against other tickets? -->
Fixes issues on the cart page that were occurring when viewing dynamic bundles.

- Issue 1 - No Remove button: In `cart.lineitem.less`, the Remove, Configure, and Move to Cart buttons were all configured to occupy the same space. This spreads them out so they no longer overlap.

- Issue 2 - Infinite Cortex calls with Dynamic Bundle in Cart: The `AppModalBundleConfigurationMain` component currently calls Cortex and updates its state in `componentDidMount`. This was re-triggering `componentDidUpdate`, resulting in an infinite loop (and about a thousand Cortex calls per minute). This PR deletes that component's `componentDidUpdate` method and instead fetches item details from Cortex in the `handleConfiguratorAddToCart`, `handleMoveToCart`, and `handleRemove` methods.

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Component Updates:
<!--Have you updated components/package.json and components/package-lock.json for any components that have been updated? -->
- [x] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests

    - Stood up a local EP instance with the Dynamic Bundles accelerator.
    - Added a nested dynamic bundle to the cart.
    - Verified that both the Configure and Remove buttons were visible on the cart, both at the root and in the bundle configuration modals.
    - Verified that adding, removing, and configuring sub items (and bundles) correctly adds, removes, and configures the items.
    - Verified that the Reference Store does not enter an infinite loop of Cortex calls.

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
