### PR TITLE
Fix am logout

### DIFF
--- a/app/src/utils/AuthService.ts
+++ b/app/src/utils/AuthService.ts
@@ -205,6 +205,13 @@ export function logout() {
   }));
 }
 
+export function logoutAccountManagementUser() {
+  logout().then(() => {
+    const keycloakLogoutRedirectUrl = `${Config.b2b.keycloak.logoutRedirectUrl}?redirect_uri=${encodeURIComponent(Config.b2b.keycloak.callbackUrl)}`;
+    window.location.href = keycloakLogoutRedirectUrl;
+  });
+}
+
 export function getRegistrationForm() {
   return new Promise(((resolve, reject) => {
     cortexFetch('/?zoom=newaccountform',

--- a/components/package-lock.json
+++ b/components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/store-components",
-  "version": "1.1.22",
+  "version": "1.1.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/store-components",
-  "version": "1.1.22",
+  "version": "1.1.23",
   "main": "build/cjs/index",
   "main:src": "src/index",
   "types": "src/index",

--- a/components/src/AppHeaderLogin/appheaderlogin.main.tsx
+++ b/components/src/AppHeaderLogin/appheaderlogin.main.tsx
@@ -26,7 +26,7 @@ import { getConfig, IEpConfig } from '../utils/ConfigProvider';
 import AppModalLoginMain from '../AppModalLogin/appmodallogin.main';
 import AppModalCartSelectMain from '../AppModalCartSelect/appmodalcartselect.main';
 import {
-  login, logout, getAccessToken,
+  login, logout, logoutAccountManagementUser, getAccessToken,
 } from '../utils/AuthService';
 import { cortexFetch, adminFetch } from '../utils/Cortex';
 import { ReactComponent as AccountIcon } from '../../../app/src/images/header-icons/account-icon.svg';
@@ -194,10 +194,8 @@ class AppHeaderLoginMain extends React.Component<AppHeaderLoginMainProps, AppHea
         openModal, openCartModal, showForgotPasswordLink, accountData,
       } = this.state;
       let keycloakLoginRedirectUrl = '';
-      let keycloakLogoutRedirectUrl = '';
       if (Config.b2b.enable) {
         keycloakLoginRedirectUrl = `${Config.b2b.keycloak.loginRedirectUrl}?client_id=${Config.b2b.keycloak.client_id}&response_type=code&scope=openid&redirect_uri=${encodeURIComponent(Config.b2b.keycloak.callbackUrl)}`;
-        keycloakLogoutRedirectUrl = `${Config.b2b.keycloak.logoutRedirectUrl}?redirect_uri=${encodeURIComponent(Config.b2b.keycloak.callbackUrl)}`;
       }
       const userName = localStorage.getItem(`${Config.cortexApi.scope}_oAuthUserName`) || localStorage.getItem(`${Config.cortexApi.scope}_oAuthUserId`);
 
@@ -252,12 +250,10 @@ class AppHeaderLoginMain extends React.Component<AppHeaderLoginMainProps, AppHea
                   )}
                   <li className="dropdown-item">
                     {(Config.b2b.enable) ? (
-                      <a href={`${keycloakLogoutRedirectUrl}`} className="login-auth-service-btn">
-                        <button className="logout-link" type="button" data-el-label="auth.logout" onClick={() => this.logoutRegisteredUser()}>
-                          <span className="icon" />
-                          {intl.get('logout')}
-                        </button>
-                      </a>
+                      <button className="logout-link" type="button" data-el-label="auth.logout" onClick={() => logoutAccountManagementUser()}>
+                        <span className="icon" />
+                        {intl.get('logout')}
+                      </button>
                     ) : (
                       <button className="logout-link" type="button" data-el-label="auth.logout" onClick={() => this.logoutRegisteredUser()}>
                         <span className="icon" />

--- a/components/src/utils/AuthService.js
+++ b/components/src/utils/AuthService.js
@@ -201,6 +201,14 @@ export function logout() {
   }));
 }
 
+export function logoutAccountManagementUser() {
+  logout().then(() => {
+    const Config = getConfig().config;
+    const keycloakLogoutRedirectUrl = `${Config.b2b.keycloak.logoutRedirectUrl}?redirect_uri=${encodeURIComponent(Config.b2b.keycloak.callbackUrl)}`;
+    window.location.href = keycloakLogoutRedirectUrl;
+  });
+}
+
 export function getRegistrationForm() {
   const Config = getConfig().config;
   return new Promise(((resolve, reject) => {


### PR DESCRIPTION
Description:
Currently when using a B2B enabled Reference Storefront there is a bug on logout that prevents proper logout from keycloak because a page redirect happens before the call to keycloak can finish.  After logging out, clicking the Login link will prompt the user with the Shop for dialog instead of taking them to the keycloak authentication page.


Linting:
- [x] No linting errors

Component Updates:
- [x] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests
Log in and out of the front-end a dozen times and it works.  If you need access to a keycloak server and a remote AM instance please let me know and I can provide credentials for testing.

Documentation:
- [ ] Requires documentation updates
