### PR TITLE
Fix display of Continue With if no stores

### DIFF
--- a/components/src/AppModalCartSelect/appmodalcartselect.main.tsx
+++ b/components/src/AppModalCartSelect/appmodalcartselect.main.tsx
@@ -48,7 +48,7 @@ interface AppModalCartSelectMainState {
 
 class AppModalCartSelectMain extends React.Component<AppModalCartSelectMainProps, AppModalCartSelectMainState> {
   static defaultProps = {
-    onContinueCart: () => {},
+    onContinueCart: () => { },
   };
 
   constructor(props) {
@@ -180,8 +180,8 @@ class AppModalCartSelectMain extends React.Component<AppModalCartSelectMainProps
                 </div>
                 <div className="action-row">
                   <div className="form-input btn-container">
-                    <button onClick={(orgAuthServiceData && !orgAuthServiceData._element) ? handleModalClose : this.continueCart} className="ep-btn primary wide" id="continue_with_cart_button" data-cmd="continue" data-toggle="collapse" data-target=".navbar-collapse" type="submit">
-                      {(orgAuthServiceData && !orgAuthServiceData._element)
+                    <button onClick={(orgAuthServiceData && !orgAuthServiceData._element) || !orgAuthServiceData ? handleModalClose : this.continueCart} className="ep-btn primary wide" id="continue_with_cart_button" data-cmd="continue" data-toggle="collapse" data-target=".navbar-collapse" type="submit">
+                      {((orgAuthServiceData && !orgAuthServiceData._element) || !orgAuthServiceData)
                         ? (intl.get('change-carts-ok'))
                         : (`${intl.get('continue-with')} ${selectedCartName}`)
                       }


### PR DESCRIPTION
Description:
<!--A brief description of changes. Things to include: WIP? Dependent PR's opened against other tickets? -->
- Display "Okay" correctly if no stores returned

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Component Updates:
<!--Have you updated components/package.json and components/package-lock.json for any components that have been updated? -->
- [x] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [x] E2E tests (npm test run with `e2e`)
- [x] Manual tests

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
