### PR TITLE
Fixed downloading csv templates from dropdown

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -44,6 +44,7 @@
     "jest-resolve": "24.8.0",
     "jest-watch-typeahead": "0.3.1",
     "jquery": "^3.4.1",
+    "js-file-download": "^0.4.8",
     "less-loader": "^5.0.0",
     "less-vars-to-js": "^1.3.0",
     "mini-css-extract-plugin": "0.7.0",

--- a/app/src/containers/b2b/B2BMain.tsx
+++ b/app/src/containers/b2b/B2BMain.tsx
@@ -22,6 +22,7 @@
 import React from 'react';
 import intl from 'react-intl-universal';
 import Modal from 'react-responsive-modal';
+import fileDownload from 'js-file-download';
 import { B2bAddAssociatesMenu, B2bSideMenu } from '@elasticpath/store-components';
 import RouteWithSubRoutes from '../../RouteWithSubRoutes';
 import { adminFetch } from '../../utils/Cortex';
@@ -103,6 +104,11 @@ export default class B2BMain extends React.Component<DashboardProps, DashboardSt
 
   handleSpreeadsheetClicked() {
     this.setState({ isImportDialogOpen: true });
+  }
+
+  handleTemplateClicked() {
+    const { exampleCsvFile } = this.state;
+    fileDownload(exampleCsvFile, 'example.csv', 'text/csv');
   }
 
   resetDialog() {
@@ -208,7 +214,10 @@ export default class B2BMain extends React.Component<DashboardProps, DashboardSt
             <div className="page-title">{intl.get('business-account')}</div>
             {associatesFormUrl && (
               <div className="quick-menu">
-                <B2bAddAssociatesMenu onSpreeadsheetClicked={() => this.handleSpreeadsheetClicked()} />
+                <B2bAddAssociatesMenu
+                  onSpreeadsheetClicked={() => this.handleSpreeadsheetClicked()}
+                  onTemplateClicked={() => this.handleTemplateClicked()}
+                />
               </div>
             )}
           </div>

--- a/components/src/B2bAddAssociatesMenu/b2b.addassociatesmenu.tsx
+++ b/components/src/B2bAddAssociatesMenu/b2b.addassociatesmenu.tsx
@@ -26,7 +26,8 @@ import { getConfig } from '../utils/ConfigProvider';
 let intl = { get: str => str };
 
 interface B2bAddAssociatesMenuProps {
-    onSpreeadsheetClicked?: (...args: any[]) => any,
+  onSpreeadsheetClicked?: (...args: any[]) => any;
+  onTemplateClicked?: (...args: any[]) => any;
 }
 interface B2bAddAssociatesMenuState {
     isOpen: boolean,
@@ -69,6 +70,14 @@ export default class B2bAddAssociatesMenu extends React.Component<B2bAddAssociat
       }
     }
 
+    handleTemplateClicked() {
+      const { onTemplateClicked } = this.props;
+
+      if (onTemplateClicked) {
+        onTemplateClicked();
+      }
+    }
+
     render() {
       const { isOpen } = this.state;
       return (
@@ -92,7 +101,15 @@ export default class B2bAddAssociatesMenu extends React.Component<B2bAddAssociat
             >
               {intl.get('upload-list')}
             </div>
-            <div className="menu-item">{intl.get('download-associate-template')}</div>
+            <div
+              className="menu-item"
+              onClick={() => this.handleTemplateClicked()}
+              onKeyDown={() => this.handleTemplateClicked()}
+              role="button"
+              tabIndex={0}
+            >
+              {intl.get('download-associate-template')}
+            </div>
           </div>
         </div>
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -12540,6 +12540,11 @@ js-cookie@^2.1.4:
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.0.tgz#1b2c279a6eece380a12168b92485265b35b1effb"
   integrity sha1-Gywnmm7s44ChIWi5JIUmWzWx7/s=
 
+js-file-download@^0.4.8:
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/js-file-download/-/js-file-download-0.4.8.tgz#f91c532acd685d8b16685672010b99473ca7f606"
+  integrity sha512-8xygX/IkjQbr/2nWqJnyc0IWOMvA1R/78HQVyexB22YZDBAEz2MG59s+ieLFKOkDFzyDDk3bezKXEjyGW5HPCw==
+
 js-levenshtein@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"


### PR DESCRIPTION
Description:
This PR fixes an issue with triggering a csv template download from a dropdown menu. Is utilizes a `js-file-download` to trigger a browser download.


Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Component Updates:
<!--Have you updated components/package.json and components/package-lock.json for any components that have been updated? -->
- [ ] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
