### PR TITLE
Removed case sensitive scope checks for faceted navigation and faceted search

### DIFF
--- a/app/src/utils/CortexLookup.ts
+++ b/app/src/utils/CortexLookup.ts
@@ -412,7 +412,7 @@ export function cortexFetchPurchaseLookupForm() {
 
 export function navigationLookup(navigationLookupCode) {
   return new Promise(((resolve, reject) => {
-    if (navigationLookupCode.includes('/') && navigationLookupCode.includes(Config.cortexApi.scope)) {
+    if (navigationLookupCode.includes('/') && navigationLookupCode.includes(Config.cortexApi.scope.toLowerCase())) {
       cortexFetch(`/${navigationLookupCode}?zoom=${navigationFormZoomArray.join()}`,
         {
           headers: {

--- a/components/package-lock.json
+++ b/components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/store-components",
-  "version": "1.1.32",
+  "version": "1.1.33",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/store-components",
-  "version": "1.1.32",
+  "version": "1.1.33",
   "main": "build/cjs/index",
   "main:src": "src/index",
   "types": "src/index",

--- a/components/src/utils/CortexLookup.js
+++ b/components/src/utils/CortexLookup.js
@@ -416,7 +416,7 @@ export function cortexFetchPurchaseLookupForm() {
 export function navigationLookup(navigationLookupCode) {
   const Config = getConfig().config;
   return new Promise(((resolve, reject) => {
-    if (navigationLookupCode.includes('/') && navigationLookupCode.includes(Config.cortexApi.scope)) {
+    if (navigationLookupCode.includes('/') && navigationLookupCode.includes(Config.cortexApi.scope.toLowerCase())) {
       cortexFetch(`/${navigationLookupCode}?zoom=${navigationFormZoomArray.join()}`,
         {
           headers: {
@@ -533,7 +533,7 @@ export function purchaseLookup(purchaseLookupCode) {
 export function searchLookup(searchKeyword) {
   const Config = getConfig().config;
   return new Promise(((resolve, reject) => {
-    if (searchKeyword.includes('/') && searchKeyword.includes(Config.cortexApi.scope)) {
+    if (searchKeyword.includes('/') && searchKeyword.includes(Config.cortexApi.scope.toLowerCase())) {
       cortexFetch(`/${searchKeyword}?zoom=${searchFormZoomArray.join()}`,
         {
           headers: {


### PR DESCRIPTION
Description:
There is a case sensitive check occuring in `CortexLookups.js` and `CortexLookups.tsx` comparing the `Config.cortexApi.scope` to a returned URL from cortex.  A store scope returned in a Cortex URL will always be lowercase.  If someone configures their scope to an uppercase value, which is valid for authentication, they are unable to select facets for either search or navigation. This PR removes the case sensitive checks.  

This is porting forward similar fixes from https://github.com/elasticpath/react-pwa-reference-storefront/pull/269 and https://github.com/elasticpath/react-pwa-reference-storefront/pull/311

Linting:
- [x] No linting errors

Component Updates:
<!--Have you updated components/package.json and components/package-lock.json for any components that have been updated? -->
- [x] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests
1. Change default scope to VESTRI
2. Navigate to the `Vehicles` category
3.  Select a facet
4. The correct selection reloads.  Prior to this you would get the infinite spinner.
5. Search for `mobile`
6. Select a facet.
7.  The correct results are returned.  Prior to this, a message would appear that says "No results found for: 'mobile'"

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
