### PR TITLE
mock requests made by appheadernavigation to allow component to show up

### DIFF
--- a/components/src/AppHeaderNavigation/MockHttpResponses/navigation_data_response.json
+++ b/components/src/AppHeaderNavigation/MockHttpResponses/navigation_data_response.json
@@ -1,0 +1,483 @@
+{
+  "self": {
+    "type": "items.item",
+    "uri": "/items/vestri_reference/qgqvhjjrhaydqny=?zoom=addtocartform,addtowishlistform,availability,code,definition,definition:assets:element,definition:components,definition:components:element,definition:components:element:code,definition:components:element:standaloneitem,definition:components:element:standaloneitem:availability,definition:components:element:standaloneitem:code,definition:components:element:standaloneitem:definition,definition:options:element,definition:options:element:selector:choice,definition:options:element:selector:choice:description,definition:options:element:selector:choice:selectaction,definition:options:element:selector:choice:selector,definition:options:element:selector:chosen,definition:options:element:selector:chosen:description,definition:options:element:selector:chosen:selectaction,definition:options:element:selector:chosen:selector,definition:options:element:value,price,rate,recommendations,recommendations:crosssell,recommendations:crosssell:element:availability,recommendations:crosssell:element:code,recommendations:crosssell:element:definition,recommendations:crosssell:element:price,recommendations:recommendation,recommendations:recommendation:element:availability,recommendations:recommendation:element:code,recommendations:recommendation:element:definition,recommendations:recommendation:element:price,recommendations:replacement,recommendations:replacement:element:availability,recommendations:replacement:element:code,recommendations:replacement:element:definition,recommendations:replacement:element:price,recommendations:upsell,recommendations:upsell:element:availability,recommendations:upsell:element:code,recommendations:upsell:element:definition,recommendations:upsell:element:price,recommendations:warranty,recommendations:warranty:element:availability,recommendations:warranty:element:code,recommendations:warranty:element:definition,recommendations:warranty:element:price",
+    "href": "http://reference.epdemos.com/cortex/items/vestri_reference/qgqvhjjrhaydqny=?zoom=addtocartform,addtowishlistform,availability,code,definition,definition:assets:element,definition:components,definition:components:element,definition:components:element:code,definition:components:element:standaloneitem,definition:components:element:standaloneitem:availability,definition:components:element:standaloneitem:code,definition:components:element:standaloneitem:definition,definition:options:element,definition:options:element:selector:choice,definition:options:element:selector:choice:description,definition:options:element:selector:choice:selectaction,definition:options:element:selector:choice:selector,definition:options:element:selector:chosen,definition:options:element:selector:chosen:description,definition:options:element:selector:chosen:selectaction,definition:options:element:selector:chosen:selector,definition:options:element:value,price,rate,recommendations,recommendations:crosssell,recommendations:crosssell:element:availability,recommendations:crosssell:element:code,recommendations:crosssell:element:definition,recommendations:crosssell:element:price,recommendations:recommendation,recommendations:recommendation:element:availability,recommendations:recommendation:element:code,recommendations:recommendation:element:definition,recommendations:recommendation:element:price,recommendations:replacement,recommendations:replacement:element:availability,recommendations:replacement:element:code,recommendations:replacement:element:definition,recommendations:replacement:element:price,recommendations:upsell,recommendations:upsell:element:availability,recommendations:upsell:element:code,recommendations:upsell:element:definition,recommendations:upsell:element:price,recommendations:warranty,recommendations:warranty:element:availability,recommendations:warranty:element:code,recommendations:warranty:element:definition,recommendations:warranty:element:price"
+  },
+  "messages": [],
+  "links": [
+    {
+      "rel": "availability",
+      "rev": "item",
+      "type": "availabilities.availability-for-item",
+      "uri": "/availabilities/items/vestri_reference/qgqvhjjrhaydqny=",
+      "href": "http://reference.epdemos.com/cortex/availabilities/items/vestri_reference/qgqvhjjrhaydqny="
+    },
+    {
+      "rel": "addtocartform",
+      "type": "carts.add-to-default-cart-form",
+      "uri": "/carts/items/vestri_reference/qgqvhjjrhaydqny=/form",
+      "href": "http://reference.epdemos.com/cortex/carts/items/vestri_reference/qgqvhjjrhaydqny=/form"
+    },
+    {
+      "rel": "cartmemberships",
+      "type": "carts.read-cart-memberships",
+      "uri": "/carts/memberships/items/vestri_reference/qgqvhjjrhaydqny=",
+      "href": "http://reference.epdemos.com/cortex/carts/memberships/items/vestri_reference/qgqvhjjrhaydqny="
+    },
+    {
+      "rel": "definition",
+      "rev": "item",
+      "type": "itemdefinitions.item-definition",
+      "uri": "/itemdefinitions/vestri_reference/qgqvhjjrhaydqny=",
+      "href": "http://reference.epdemos.com/cortex/itemdefinitions/vestri_reference/qgqvhjjrhaydqny="
+    },
+    {
+      "rel": "code",
+      "rev": "item",
+      "type": "items.code-for-item",
+      "uri": "/items/code/items/vestri_reference/qgqvhjjrhaydqny=",
+      "href": "http://reference.epdemos.com/cortex/items/code/items/vestri_reference/qgqvhjjrhaydqny="
+    },
+    {
+      "rel": "price",
+      "rev": "item",
+      "type": "prices.price-for-item",
+      "uri": "/prices/items/vestri_reference/qgqvhjjrhaydqny=",
+      "href": "http://reference.epdemos.com/cortex/prices/items/vestri_reference/qgqvhjjrhaydqny="
+    },
+    {
+      "rel": "appliedpromotions",
+      "rev": "item",
+      "type": "promotions.applied-promotions-for-item",
+      "uri": "/promotions/items/vestri_reference/qgqvhjjrhaydqny=/applied",
+      "href": "http://reference.epdemos.com/cortex/promotions/items/vestri_reference/qgqvhjjrhaydqny=/applied"
+    },
+    {
+      "rel": "recommendations",
+      "type": "recommendations.item-recommendation-groups",
+      "uri": "/recommendations/items/vestri_reference/qgqvhjjrhaydqny=",
+      "href": "http://reference.epdemos.com/cortex/recommendations/items/vestri_reference/qgqvhjjrhaydqny="
+    },
+    {
+      "rel": "addtowishlistform",
+      "type": "wishlists.add-item-to-wishlist-form",
+      "uri": "/wishlists/items/vestri_reference/qgqvhjjrhaydqny=/form",
+      "href": "http://reference.epdemos.com/cortex/wishlists/items/vestri_reference/qgqvhjjrhaydqny=/form"
+    },
+    {
+      "rel": "wishlistmemberships",
+      "type": "wishlists.read-wishlist-memberships",
+      "uri": "/wishlists/memberships/items/vestri_reference/qgqvhjjrhaydqny=",
+      "href": "http://reference.epdemos.com/cortex/wishlists/memberships/items/vestri_reference/qgqvhjjrhaydqny="
+    }
+  ],
+  "_addtocartform": [
+    {
+      "self": {
+        "type": "carts.add-to-default-cart-form",
+        "uri": "/carts/items/vestri_reference/qgqvhjjrhaydqny=/form",
+        "href": "http://reference.epdemos.com/cortex/carts/items/vestri_reference/qgqvhjjrhaydqny=/form"
+      },
+      "messages": [],
+      "links": [
+        {
+          "rel": "addtodefaultcartaction",
+          "type": "carts.add-to-default-cart-form",
+          "uri": "/carts/items/vestri_reference/qgqvhjjrhaydqny=/form",
+          "href": "http://reference.epdemos.com/cortex/carts/items/vestri_reference/qgqvhjjrhaydqny=/form"
+        }
+      ],
+      "configuration": {},
+      "quantity": 0
+    }
+  ],
+  "_addtowishlistform": [
+    {
+      "self": {
+        "type": "wishlists.add-item-to-wishlist-form",
+        "uri": "/wishlists/items/vestri_reference/qgqvhjjrhaydqny=/form",
+        "href": "http://reference.epdemos.com/cortex/wishlists/items/vestri_reference/qgqvhjjrhaydqny=/form"
+      },
+      "messages": [],
+      "links": [
+        {
+          "rel": "addtodefaultwishlistaction",
+          "type": "wishlists.add-item-to-wishlist-form",
+          "uri": "/wishlists/items/vestri_reference/qgqvhjjrhaydqny=/form",
+          "href": "http://reference.epdemos.com/cortex/wishlists/items/vestri_reference/qgqvhjjrhaydqny=/form"
+        }
+      ]
+    }
+  ],
+  "_availability": [
+    {
+      "self": {
+        "type": "availabilities.availability-for-item",
+        "uri": "/availabilities/items/vestri_reference/qgqvhjjrhaydqny=",
+        "href": "http://reference.epdemos.com/cortex/availabilities/items/vestri_reference/qgqvhjjrhaydqny="
+      },
+      "messages": [],
+      "links": [],
+      "state": "AVAILABLE"
+    }
+  ],
+  "_code": [
+    {
+      "self": {
+        "type": "items.code-for-item",
+        "uri": "/items/code/items/vestri_reference/qgqvhjjrhaydqny=",
+        "href": "http://reference.epdemos.com/cortex/items/code/items/vestri_reference/qgqvhjjrhaydqny="
+      },
+      "messages": [],
+      "links": [],
+      "code": "18087"
+    }
+  ],
+  "_definition": [
+    {
+      "self": {
+        "type": "itemdefinitions.item-definition",
+        "uri": "/itemdefinitions/vestri_reference/qgqvhjjrhaydqny=",
+        "href": "http://reference.epdemos.com/cortex/itemdefinitions/vestri_reference/qgqvhjjrhaydqny="
+      },
+      "messages": [],
+      "links": [],
+      "_components": [
+        {
+          "self": {
+            "type": "itemdefinitions.item-definition-components",
+            "uri": "/itemdefinitions/vestri_reference/qgqvhjjrhaydqny=/components",
+            "href": "http://reference.epdemos.com/cortex/itemdefinitions/vestri_reference/qgqvhjjrhaydqny=/components"
+          },
+          "messages": [],
+          "links": [],
+          "_element": [
+            {
+              "self": {
+                "type": "itemdefinitions.item-definition-component",
+                "uri": "/itemdefinitions/vestri_reference/qgqvhjjrhaydqny=/components/shmsizbvgrqwenrrgmwwmyzshewtin3gmmwwezrzmuwwcnjvgyzdmolemjrdqna=",
+                "href": "http://reference.epdemos.com/cortex/itemdefinitions/vestri_reference/qgqvhjjrhaydqny=/components/shmsizbvgrqwenrrgmwwmyzshewtin3gmmwwezrzmuwwcnjvgyzdmolemjrdqna="
+              },
+              "messages": [],
+              "links": [],
+              "_standaloneitem": [
+                {
+                  "self": {
+                    "type": "items.item",
+                    "uri": "/items/vestri_reference/qgqvhjjrga2dqna=",
+                    "href": "http://reference.epdemos.com/cortex/items/vestri_reference/qgqvhjjrga2dqna="
+                  },
+                  "messages": [],
+                  "links": [],
+                  "_availability": [
+                    {
+                      "self": {
+                        "type": "availabilities.availability-for-item",
+                        "uri": "/availabilities/items/vestri_reference/qgqvhjjrga2dqna=",
+                        "href": "http://reference.epdemos.com/cortex/availabilities/items/vestri_reference/qgqvhjjrga2dqna="
+                      },
+                      "messages": [],
+                      "links": [],
+                      "state": "AVAILABLE"
+                    }
+                  ],
+                  "_code": [
+                    {
+                      "self": {
+                        "type": "items.code-for-item",
+                        "uri": "/items/code/items/vestri_reference/qgqvhjjrga2dqna=",
+                        "href": "http://reference.epdemos.com/cortex/items/code/items/vestri_reference/qgqvhjjrga2dqna="
+                      },
+                      "messages": [],
+                      "links": [],
+                      "code": "10484"
+                    }
+                  ],
+                  "_definition": [
+                    {
+                      "self": {
+                        "type": "itemdefinitions.item-definition",
+                        "uri": "/itemdefinitions/vestri_reference/qgqvhjjrga2dqna=",
+                        "href": "http://reference.epdemos.com/cortex/itemdefinitions/vestri_reference/qgqvhjjrga2dqna="
+                      },
+                      "messages": [],
+                      "links": [],
+                      "details": [
+                        {
+                          "display-name": "",
+                          "display-value": "Combine all the popular options into one east to use trim package which allows you to get everything you want.",
+                          "name": "DESCRIPTION",
+                          "value": "Combine all the popular options into one east to use trim package which allows you to get everything you want."
+                        }
+                      ],
+                      "display-name": "V Trim Package"
+                    }
+                  ]
+                }
+              ],
+              "details": [
+                {
+                  "display-name": "",
+                  "display-value": "Combine all the popular options into one east to use trim package which allows you to get everything you want.",
+                  "name": "DESCRIPTION",
+                  "value": "Combine all the popular options into one east to use trim package which allows you to get everything you want."
+                }
+              ],
+              "display-name": "V Trim Package",
+              "quantity": 1
+            },
+            {
+              "self": {
+                "type": "itemdefinitions.item-definition-component",
+                "uri": "/itemdefinitions/vestri_reference/qgqvhjjrhaydqny=/components/shmsiyjsgnrdmnjsg4wtkyrsgywtizdghewtsyrrmiwtkzjxgmzdczlbha2dgmy=",
+                "href": "http://reference.epdemos.com/cortex/itemdefinitions/vestri_reference/qgqvhjjrhaydqny=/components/shmsiyjsgnrdmnjsg4wtkyrsgywtizdghewtsyrrmiwtkzjxgmzdczlbha2dgmy="
+              },
+              "messages": [],
+              "links": [],
+              "_standaloneitem": [
+                {
+                  "self": {
+                    "type": "items.item",
+                    "uri": "/items/vestri_reference/qgqvhjjzg43temy=",
+                    "href": "http://reference.epdemos.com/cortex/items/vestri_reference/qgqvhjjzg43temy="
+                  },
+                  "messages": [],
+                  "links": [],
+                  "_availability": [
+                    {
+                      "self": {
+                        "type": "availabilities.availability-for-item",
+                        "uri": "/availabilities/items/vestri_reference/qgqvhjjzg43temy=",
+                        "href": "http://reference.epdemos.com/cortex/availabilities/items/vestri_reference/qgqvhjjzg43temy="
+                      },
+                      "messages": [],
+                      "links": [],
+                      "state": "AVAILABLE"
+                    }
+                  ],
+                  "_code": [
+                    {
+                      "self": {
+                        "type": "items.code-for-item",
+                        "uri": "/items/code/items/vestri_reference/qgqvhjjzg43temy=",
+                        "href": "http://reference.epdemos.com/cortex/items/code/items/vestri_reference/qgqvhjjzg43temy="
+                      },
+                      "messages": [],
+                      "links": [],
+                      "code": "97723"
+                    }
+                  ],
+                  "_definition": [
+                    {
+                      "self": {
+                        "type": "itemdefinitions.item-definition",
+                        "uri": "/itemdefinitions/vestri_reference/qgqvhjjzg43temy=",
+                        "href": "http://reference.epdemos.com/cortex/itemdefinitions/vestri_reference/qgqvhjjzg43temy="
+                      },
+                      "messages": [],
+                      "links": [],
+                      "details": [
+                        {
+                          "display-name": "",
+                          "display-value": "Cruise Control is great when you leave the city limits. But what about when you’re driving on busy highways and freeways? Adaptive Cruise Control lets you cruise in traffic by ‘reading’ the traffic ahead and managing your speed and distance as it changes.",
+                          "name": "DESCRIPTION",
+                          "value": "Cruise Control is great when you leave the city limits. But what about when you’re driving on busy highways and freeways? Adaptive Cruise Control lets you cruise in traffic by ‘reading’ the traffic ahead and managing your speed and distance as it changes."
+                        }
+                      ],
+                      "display-name": "Adaptive Cruise Control"
+                    }
+                  ]
+                }
+              ],
+              "details": [
+                {
+                  "display-name": "",
+                  "display-value": "Cruise Control is great when you leave the city limits. But what about when you’re driving on busy highways and freeways? Adaptive Cruise Control lets you cruise in traffic by ‘reading’ the traffic ahead and managing your speed and distance as it changes.",
+                  "name": "DESCRIPTION",
+                  "value": "Cruise Control is great when you leave the city limits. But what about when you’re driving on busy highways and freeways? Adaptive Cruise Control lets you cruise in traffic by ‘reading’ the traffic ahead and managing your speed and distance as it changes."
+                }
+              ],
+              "display-name": "Adaptive Cruise Control",
+              "quantity": 1
+            },
+            {
+              "self": {
+                "type": "itemdefinitions.item-definition-component",
+                "uri": "/itemdefinitions/vestri_reference/qgqvhjjrhaydqny=/components/shmsintdgvqtmnrqhawtemlggmwtinjxmewwenldmuwtiyjxgm2tcmrqmm4tioa=",
+                "href": "http://reference.epdemos.com/cortex/itemdefinitions/vestri_reference/qgqvhjjrhaydqny=/components/shmsintdgvqtmnrqhawtemlggmwtinjxmewwenldmuwtiyjxgm2tcmrqmm4tioa="
+              },
+              "messages": [],
+              "links": [],
+              "_standaloneitem": [
+                {
+                  "self": {
+                    "type": "items.item",
+                    "uri": "/items/vestri_reference/qgqvhjjugu3dgmq=",
+                    "href": "http://reference.epdemos.com/cortex/items/vestri_reference/qgqvhjjugu3dgmq="
+                  },
+                  "messages": [],
+                  "links": [],
+                  "_availability": [
+                    {
+                      "self": {
+                        "type": "availabilities.availability-for-item",
+                        "uri": "/availabilities/items/vestri_reference/qgqvhjjugu3dgmq=",
+                        "href": "http://reference.epdemos.com/cortex/availabilities/items/vestri_reference/qgqvhjjugu3dgmq="
+                      },
+                      "messages": [],
+                      "links": [],
+                      "state": "AVAILABLE"
+                    }
+                  ],
+                  "_code": [
+                    {
+                      "self": {
+                        "type": "items.code-for-item",
+                        "uri": "/items/code/items/vestri_reference/qgqvhjjugu3dgmq=",
+                        "href": "http://reference.epdemos.com/cortex/items/code/items/vestri_reference/qgqvhjjugu3dgmq="
+                      },
+                      "messages": [],
+                      "links": [],
+                      "code": "45632"
+                    }
+                  ],
+                  "_definition": [
+                    {
+                      "self": {
+                        "type": "itemdefinitions.item-definition",
+                        "uri": "/itemdefinitions/vestri_reference/qgqvhjjugu3dgmq=",
+                        "href": "http://reference.epdemos.com/cortex/itemdefinitions/vestri_reference/qgqvhjjugu3dgmq="
+                      },
+                      "messages": [],
+                      "links": [],
+                      "details": [
+                        {
+                          "display-name": "",
+                          "display-value": "Vestri's Blind Spot Warning System with cross-traffic alert, is a driver assist feature that helps detect vehicles in blind spots during normal driving and traffic approaching from the sides when reversing out of parking spots.",
+                          "name": "DESCRIPTION",
+                          "value": "Vestri's Blind Spot Warning System with cross-traffic alert, is a driver assist feature that helps detect vehicles in blind spots during normal driving and traffic approaching from the sides when reversing out of parking spots."
+                        }
+                      ],
+                      "display-name": "Blind Spot Warning"
+                    }
+                  ]
+                }
+              ],
+              "details": [
+                {
+                  "display-name": "",
+                  "display-value": "Vestri's Blind Spot Warning System with cross-traffic alert, is a driver assist feature that helps detect vehicles in blind spots during normal driving and traffic approaching from the sides when reversing out of parking spots.",
+                  "name": "DESCRIPTION",
+                  "value": "Vestri's Blind Spot Warning System with cross-traffic alert, is a driver assist feature that helps detect vehicles in blind spots during normal driving and traffic approaching from the sides when reversing out of parking spots."
+                }
+              ],
+              "display-name": "Blind Spot Warning",
+              "quantity": 1
+            }
+          ]
+        }
+      ],
+      "details": [
+        {
+          "display-name": "",
+          "display-value": "Step up to the next level by including everything in our V package and more, with our top of the line premium package.",
+          "name": "DESCRIPTION",
+          "value": "Step up to the next level by including everything in our V package and more, with our top of the line premium package."
+        }
+      ],
+      "display-name": "VE Trim Package"
+    }
+  ],
+  "_price": [
+    {
+      "self": {
+        "type": "prices.price-for-item",
+        "uri": "/prices/items/vestri_reference/qgqvhjjrhaydqny=",
+        "href": "http://reference.epdemos.com/cortex/prices/items/vestri_reference/qgqvhjjrhaydqny="
+      },
+      "messages": [],
+      "links": [],
+      "list-price": [
+        {
+          "amount": 477.36,
+          "currency": "CAD",
+          "display": "$477.36"
+        }
+      ],
+      "purchase-price": [
+        {
+          "amount": 477.36,
+          "currency": "CAD",
+          "display": "$477.36"
+        }
+      ]
+    }
+  ],
+  "_recommendations": [
+    {
+      "self": {
+        "type": "recommendations.item-recommendation-groups",
+        "uri": "/recommendations/items/vestri_reference/qgqvhjjrhaydqny=",
+        "href": "http://reference.epdemos.com/cortex/recommendations/items/vestri_reference/qgqvhjjrhaydqny="
+      },
+      "messages": [],
+      "links": [],
+      "_crosssell": [
+        {
+          "pagination": {
+            "current": 1,
+            "page-size": 5,
+            "pages": 1,
+            "results": 0,
+            "results-on-page": 0
+          }
+        }
+      ],
+      "_recommendation": [
+        {
+          "pagination": {
+            "current": 1,
+            "page-size": 5,
+            "pages": 1,
+            "results": 0,
+            "results-on-page": 0
+          }
+        }
+      ],
+      "_replacement": [
+        {
+          "pagination": {
+            "current": 1,
+            "page-size": 5,
+            "pages": 1,
+            "results": 0,
+            "results-on-page": 0
+          }
+        }
+      ],
+      "_upsell": [
+        {
+          "pagination": {
+            "current": 1,
+            "page-size": 5,
+            "pages": 1,
+            "results": 0,
+            "results-on-page": 0
+          }
+        }
+      ],
+      "_warranty": [
+        {
+          "pagination": {
+            "current": 1,
+            "page-size": 5,
+            "pages": 1,
+            "results": 0,
+            "results-on-page": 0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/components/src/AppHeaderNavigation/MockHttpResponses/navigation_data_response.json
+++ b/components/src/AppHeaderNavigation/MockHttpResponses/navigation_data_response.json
@@ -1,483 +1,1051 @@
 {
-  "self": {
-    "type": "items.item",
-    "uri": "/items/vestri_reference/qgqvhjjrhaydqny=?zoom=addtocartform,addtowishlistform,availability,code,definition,definition:assets:element,definition:components,definition:components:element,definition:components:element:code,definition:components:element:standaloneitem,definition:components:element:standaloneitem:availability,definition:components:element:standaloneitem:code,definition:components:element:standaloneitem:definition,definition:options:element,definition:options:element:selector:choice,definition:options:element:selector:choice:description,definition:options:element:selector:choice:selectaction,definition:options:element:selector:choice:selector,definition:options:element:selector:chosen,definition:options:element:selector:chosen:description,definition:options:element:selector:chosen:selectaction,definition:options:element:selector:chosen:selector,definition:options:element:value,price,rate,recommendations,recommendations:crosssell,recommendations:crosssell:element:availability,recommendations:crosssell:element:code,recommendations:crosssell:element:definition,recommendations:crosssell:element:price,recommendations:recommendation,recommendations:recommendation:element:availability,recommendations:recommendation:element:code,recommendations:recommendation:element:definition,recommendations:recommendation:element:price,recommendations:replacement,recommendations:replacement:element:availability,recommendations:replacement:element:code,recommendations:replacement:element:definition,recommendations:replacement:element:price,recommendations:upsell,recommendations:upsell:element:availability,recommendations:upsell:element:code,recommendations:upsell:element:definition,recommendations:upsell:element:price,recommendations:warranty,recommendations:warranty:element:availability,recommendations:warranty:element:code,recommendations:warranty:element:definition,recommendations:warranty:element:price",
-    "href": "http://reference.epdemos.com/cortex/items/vestri_reference/qgqvhjjrhaydqny=?zoom=addtocartform,addtowishlistform,availability,code,definition,definition:assets:element,definition:components,definition:components:element,definition:components:element:code,definition:components:element:standaloneitem,definition:components:element:standaloneitem:availability,definition:components:element:standaloneitem:code,definition:components:element:standaloneitem:definition,definition:options:element,definition:options:element:selector:choice,definition:options:element:selector:choice:description,definition:options:element:selector:choice:selectaction,definition:options:element:selector:choice:selector,definition:options:element:selector:chosen,definition:options:element:selector:chosen:description,definition:options:element:selector:chosen:selectaction,definition:options:element:selector:chosen:selector,definition:options:element:value,price,rate,recommendations,recommendations:crosssell,recommendations:crosssell:element:availability,recommendations:crosssell:element:code,recommendations:crosssell:element:definition,recommendations:crosssell:element:price,recommendations:recommendation,recommendations:recommendation:element:availability,recommendations:recommendation:element:code,recommendations:recommendation:element:definition,recommendations:recommendation:element:price,recommendations:replacement,recommendations:replacement:element:availability,recommendations:replacement:element:code,recommendations:replacement:element:definition,recommendations:replacement:element:price,recommendations:upsell,recommendations:upsell:element:availability,recommendations:upsell:element:code,recommendations:upsell:element:definition,recommendations:upsell:element:price,recommendations:warranty,recommendations:warranty:element:availability,recommendations:warranty:element:code,recommendations:warranty:element:definition,recommendations:warranty:element:price"
-  },
-  "messages": [],
-  "links": [
-    {
-      "rel": "availability",
-      "rev": "item",
-      "type": "availabilities.availability-for-item",
-      "uri": "/availabilities/items/vestri_reference/qgqvhjjrhaydqny=",
-      "href": "http://reference.epdemos.com/cortex/availabilities/items/vestri_reference/qgqvhjjrhaydqny="
-    },
-    {
-      "rel": "addtocartform",
-      "type": "carts.add-to-default-cart-form",
-      "uri": "/carts/items/vestri_reference/qgqvhjjrhaydqny=/form",
-      "href": "http://reference.epdemos.com/cortex/carts/items/vestri_reference/qgqvhjjrhaydqny=/form"
-    },
-    {
-      "rel": "cartmemberships",
-      "type": "carts.read-cart-memberships",
-      "uri": "/carts/memberships/items/vestri_reference/qgqvhjjrhaydqny=",
-      "href": "http://reference.epdemos.com/cortex/carts/memberships/items/vestri_reference/qgqvhjjrhaydqny="
-    },
-    {
-      "rel": "definition",
-      "rev": "item",
-      "type": "itemdefinitions.item-definition",
-      "uri": "/itemdefinitions/vestri_reference/qgqvhjjrhaydqny=",
-      "href": "http://reference.epdemos.com/cortex/itemdefinitions/vestri_reference/qgqvhjjrhaydqny="
-    },
-    {
-      "rel": "code",
-      "rev": "item",
-      "type": "items.code-for-item",
-      "uri": "/items/code/items/vestri_reference/qgqvhjjrhaydqny=",
-      "href": "http://reference.epdemos.com/cortex/items/code/items/vestri_reference/qgqvhjjrhaydqny="
-    },
-    {
-      "rel": "price",
-      "rev": "item",
-      "type": "prices.price-for-item",
-      "uri": "/prices/items/vestri_reference/qgqvhjjrhaydqny=",
-      "href": "http://reference.epdemos.com/cortex/prices/items/vestri_reference/qgqvhjjrhaydqny="
-    },
-    {
-      "rel": "appliedpromotions",
-      "rev": "item",
-      "type": "promotions.applied-promotions-for-item",
-      "uri": "/promotions/items/vestri_reference/qgqvhjjrhaydqny=/applied",
-      "href": "http://reference.epdemos.com/cortex/promotions/items/vestri_reference/qgqvhjjrhaydqny=/applied"
-    },
-    {
-      "rel": "recommendations",
-      "type": "recommendations.item-recommendation-groups",
-      "uri": "/recommendations/items/vestri_reference/qgqvhjjrhaydqny=",
-      "href": "http://reference.epdemos.com/cortex/recommendations/items/vestri_reference/qgqvhjjrhaydqny="
-    },
-    {
-      "rel": "addtowishlistform",
-      "type": "wishlists.add-item-to-wishlist-form",
-      "uri": "/wishlists/items/vestri_reference/qgqvhjjrhaydqny=/form",
-      "href": "http://reference.epdemos.com/cortex/wishlists/items/vestri_reference/qgqvhjjrhaydqny=/form"
-    },
-    {
-      "rel": "wishlistmemberships",
-      "type": "wishlists.read-wishlist-memberships",
-      "uri": "/wishlists/memberships/items/vestri_reference/qgqvhjjrhaydqny=",
-      "href": "http://reference.epdemos.com/cortex/wishlists/memberships/items/vestri_reference/qgqvhjjrhaydqny="
-    }
-  ],
-  "_addtocartform": [
-    {
-      "self": {
-        "type": "carts.add-to-default-cart-form",
-        "uri": "/carts/items/vestri_reference/qgqvhjjrhaydqny=/form",
-        "href": "http://reference.epdemos.com/cortex/carts/items/vestri_reference/qgqvhjjrhaydqny=/form"
-      },
-      "messages": [],
-      "links": [
-        {
-          "rel": "addtodefaultcartaction",
-          "type": "carts.add-to-default-cart-form",
-          "uri": "/carts/items/vestri_reference/qgqvhjjrhaydqny=/form",
-          "href": "http://reference.epdemos.com/cortex/carts/items/vestri_reference/qgqvhjjrhaydqny=/form"
-        }
-      ],
-      "configuration": {},
-      "quantity": 0
-    }
-  ],
-  "_addtowishlistform": [
-    {
-      "self": {
-        "type": "wishlists.add-item-to-wishlist-form",
-        "uri": "/wishlists/items/vestri_reference/qgqvhjjrhaydqny=/form",
-        "href": "http://reference.epdemos.com/cortex/wishlists/items/vestri_reference/qgqvhjjrhaydqny=/form"
-      },
-      "messages": [],
-      "links": [
-        {
-          "rel": "addtodefaultwishlistaction",
-          "type": "wishlists.add-item-to-wishlist-form",
-          "uri": "/wishlists/items/vestri_reference/qgqvhjjrhaydqny=/form",
-          "href": "http://reference.epdemos.com/cortex/wishlists/items/vestri_reference/qgqvhjjrhaydqny=/form"
-        }
-      ]
-    }
-  ],
-  "_availability": [
-    {
-      "self": {
-        "type": "availabilities.availability-for-item",
-        "uri": "/availabilities/items/vestri_reference/qgqvhjjrhaydqny=",
-        "href": "http://reference.epdemos.com/cortex/availabilities/items/vestri_reference/qgqvhjjrhaydqny="
-      },
-      "messages": [],
-      "links": [],
-      "state": "AVAILABLE"
-    }
-  ],
-  "_code": [
-    {
-      "self": {
-        "type": "items.code-for-item",
-        "uri": "/items/code/items/vestri_reference/qgqvhjjrhaydqny=",
-        "href": "http://reference.epdemos.com/cortex/items/code/items/vestri_reference/qgqvhjjrhaydqny="
-      },
-      "messages": [],
-      "links": [],
-      "code": "18087"
-    }
-  ],
-  "_definition": [
-    {
-      "self": {
-        "type": "itemdefinitions.item-definition",
-        "uri": "/itemdefinitions/vestri_reference/qgqvhjjrhaydqny=",
-        "href": "http://reference.epdemos.com/cortex/itemdefinitions/vestri_reference/qgqvhjjrhaydqny="
-      },
-      "messages": [],
-      "links": [],
-      "_components": [
-        {
-          "self": {
-            "type": "itemdefinitions.item-definition-components",
-            "uri": "/itemdefinitions/vestri_reference/qgqvhjjrhaydqny=/components",
-            "href": "http://reference.epdemos.com/cortex/itemdefinitions/vestri_reference/qgqvhjjrhaydqny=/components"
-          },
-          "messages": [],
-          "links": [],
-          "_element": [
-            {
-              "self": {
-                "type": "itemdefinitions.item-definition-component",
-                "uri": "/itemdefinitions/vestri_reference/qgqvhjjrhaydqny=/components/shmsizbvgrqwenrrgmwwmyzshewtin3gmmwwezrzmuwwcnjvgyzdmolemjrdqna=",
-                "href": "http://reference.epdemos.com/cortex/itemdefinitions/vestri_reference/qgqvhjjrhaydqny=/components/shmsizbvgrqwenrrgmwwmyzshewtin3gmmwwezrzmuwwcnjvgyzdmolemjrdqna="
-              },
-              "messages": [],
-              "links": [],
-              "_standaloneitem": [
-                {
-                  "self": {
-                    "type": "items.item",
-                    "uri": "/items/vestri_reference/qgqvhjjrga2dqna=",
-                    "href": "http://reference.epdemos.com/cortex/items/vestri_reference/qgqvhjjrga2dqna="
-                  },
-                  "messages": [],
-                  "links": [],
-                  "_availability": [
-                    {
-                      "self": {
-                        "type": "availabilities.availability-for-item",
-                        "uri": "/availabilities/items/vestri_reference/qgqvhjjrga2dqna=",
-                        "href": "http://reference.epdemos.com/cortex/availabilities/items/vestri_reference/qgqvhjjrga2dqna="
-                      },
-                      "messages": [],
-                      "links": [],
-                      "state": "AVAILABLE"
-                    }
-                  ],
-                  "_code": [
-                    {
-                      "self": {
-                        "type": "items.code-for-item",
-                        "uri": "/items/code/items/vestri_reference/qgqvhjjrga2dqna=",
-                        "href": "http://reference.epdemos.com/cortex/items/code/items/vestri_reference/qgqvhjjrga2dqna="
-                      },
-                      "messages": [],
-                      "links": [],
-                      "code": "10484"
-                    }
-                  ],
-                  "_definition": [
-                    {
-                      "self": {
-                        "type": "itemdefinitions.item-definition",
-                        "uri": "/itemdefinitions/vestri_reference/qgqvhjjrga2dqna=",
-                        "href": "http://reference.epdemos.com/cortex/itemdefinitions/vestri_reference/qgqvhjjrga2dqna="
-                      },
-                      "messages": [],
-                      "links": [],
-                      "details": [
-                        {
-                          "display-name": "",
-                          "display-value": "Combine all the popular options into one east to use trim package which allows you to get everything you want.",
-                          "name": "DESCRIPTION",
-                          "value": "Combine all the popular options into one east to use trim package which allows you to get everything you want."
-                        }
-                      ],
-                      "display-name": "V Trim Package"
-                    }
-                  ]
-                }
-              ],
-              "details": [
-                {
-                  "display-name": "",
-                  "display-value": "Combine all the popular options into one east to use trim package which allows you to get everything you want.",
-                  "name": "DESCRIPTION",
-                  "value": "Combine all the popular options into one east to use trim package which allows you to get everything you want."
-                }
-              ],
-              "display-name": "V Trim Package",
-              "quantity": 1
-            },
-            {
-              "self": {
-                "type": "itemdefinitions.item-definition-component",
-                "uri": "/itemdefinitions/vestri_reference/qgqvhjjrhaydqny=/components/shmsiyjsgnrdmnjsg4wtkyrsgywtizdghewtsyrrmiwtkzjxgmzdczlbha2dgmy=",
-                "href": "http://reference.epdemos.com/cortex/itemdefinitions/vestri_reference/qgqvhjjrhaydqny=/components/shmsiyjsgnrdmnjsg4wtkyrsgywtizdghewtsyrrmiwtkzjxgmzdczlbha2dgmy="
-              },
-              "messages": [],
-              "links": [],
-              "_standaloneitem": [
-                {
-                  "self": {
-                    "type": "items.item",
-                    "uri": "/items/vestri_reference/qgqvhjjzg43temy=",
-                    "href": "http://reference.epdemos.com/cortex/items/vestri_reference/qgqvhjjzg43temy="
-                  },
-                  "messages": [],
-                  "links": [],
-                  "_availability": [
-                    {
-                      "self": {
-                        "type": "availabilities.availability-for-item",
-                        "uri": "/availabilities/items/vestri_reference/qgqvhjjzg43temy=",
-                        "href": "http://reference.epdemos.com/cortex/availabilities/items/vestri_reference/qgqvhjjzg43temy="
-                      },
-                      "messages": [],
-                      "links": [],
-                      "state": "AVAILABLE"
-                    }
-                  ],
-                  "_code": [
-                    {
-                      "self": {
-                        "type": "items.code-for-item",
-                        "uri": "/items/code/items/vestri_reference/qgqvhjjzg43temy=",
-                        "href": "http://reference.epdemos.com/cortex/items/code/items/vestri_reference/qgqvhjjzg43temy="
-                      },
-                      "messages": [],
-                      "links": [],
-                      "code": "97723"
-                    }
-                  ],
-                  "_definition": [
-                    {
-                      "self": {
-                        "type": "itemdefinitions.item-definition",
-                        "uri": "/itemdefinitions/vestri_reference/qgqvhjjzg43temy=",
-                        "href": "http://reference.epdemos.com/cortex/itemdefinitions/vestri_reference/qgqvhjjzg43temy="
-                      },
-                      "messages": [],
-                      "links": [],
-                      "details": [
-                        {
-                          "display-name": "",
-                          "display-value": "Cruise Control is great when you leave the city limits. But what about when you’re driving on busy highways and freeways? Adaptive Cruise Control lets you cruise in traffic by ‘reading’ the traffic ahead and managing your speed and distance as it changes.",
-                          "name": "DESCRIPTION",
-                          "value": "Cruise Control is great when you leave the city limits. But what about when you’re driving on busy highways and freeways? Adaptive Cruise Control lets you cruise in traffic by ‘reading’ the traffic ahead and managing your speed and distance as it changes."
-                        }
-                      ],
-                      "display-name": "Adaptive Cruise Control"
-                    }
-                  ]
-                }
-              ],
-              "details": [
-                {
-                  "display-name": "",
-                  "display-value": "Cruise Control is great when you leave the city limits. But what about when you’re driving on busy highways and freeways? Adaptive Cruise Control lets you cruise in traffic by ‘reading’ the traffic ahead and managing your speed and distance as it changes.",
-                  "name": "DESCRIPTION",
-                  "value": "Cruise Control is great when you leave the city limits. But what about when you’re driving on busy highways and freeways? Adaptive Cruise Control lets you cruise in traffic by ‘reading’ the traffic ahead and managing your speed and distance as it changes."
-                }
-              ],
-              "display-name": "Adaptive Cruise Control",
-              "quantity": 1
-            },
-            {
-              "self": {
-                "type": "itemdefinitions.item-definition-component",
-                "uri": "/itemdefinitions/vestri_reference/qgqvhjjrhaydqny=/components/shmsintdgvqtmnrqhawtemlggmwtinjxmewwenldmuwtiyjxgm2tcmrqmm4tioa=",
-                "href": "http://reference.epdemos.com/cortex/itemdefinitions/vestri_reference/qgqvhjjrhaydqny=/components/shmsintdgvqtmnrqhawtemlggmwtinjxmewwenldmuwtiyjxgm2tcmrqmm4tioa="
-              },
-              "messages": [],
-              "links": [],
-              "_standaloneitem": [
-                {
-                  "self": {
-                    "type": "items.item",
-                    "uri": "/items/vestri_reference/qgqvhjjugu3dgmq=",
-                    "href": "http://reference.epdemos.com/cortex/items/vestri_reference/qgqvhjjugu3dgmq="
-                  },
-                  "messages": [],
-                  "links": [],
-                  "_availability": [
-                    {
-                      "self": {
-                        "type": "availabilities.availability-for-item",
-                        "uri": "/availabilities/items/vestri_reference/qgqvhjjugu3dgmq=",
-                        "href": "http://reference.epdemos.com/cortex/availabilities/items/vestri_reference/qgqvhjjugu3dgmq="
-                      },
-                      "messages": [],
-                      "links": [],
-                      "state": "AVAILABLE"
-                    }
-                  ],
-                  "_code": [
-                    {
-                      "self": {
-                        "type": "items.code-for-item",
-                        "uri": "/items/code/items/vestri_reference/qgqvhjjugu3dgmq=",
-                        "href": "http://reference.epdemos.com/cortex/items/code/items/vestri_reference/qgqvhjjugu3dgmq="
-                      },
-                      "messages": [],
-                      "links": [],
-                      "code": "45632"
-                    }
-                  ],
-                  "_definition": [
-                    {
-                      "self": {
-                        "type": "itemdefinitions.item-definition",
-                        "uri": "/itemdefinitions/vestri_reference/qgqvhjjugu3dgmq=",
-                        "href": "http://reference.epdemos.com/cortex/itemdefinitions/vestri_reference/qgqvhjjugu3dgmq="
-                      },
-                      "messages": [],
-                      "links": [],
-                      "details": [
-                        {
-                          "display-name": "",
-                          "display-value": "Vestri's Blind Spot Warning System with cross-traffic alert, is a driver assist feature that helps detect vehicles in blind spots during normal driving and traffic approaching from the sides when reversing out of parking spots.",
-                          "name": "DESCRIPTION",
-                          "value": "Vestri's Blind Spot Warning System with cross-traffic alert, is a driver assist feature that helps detect vehicles in blind spots during normal driving and traffic approaching from the sides when reversing out of parking spots."
-                        }
-                      ],
-                      "display-name": "Blind Spot Warning"
-                    }
-                  ]
-                }
-              ],
-              "details": [
-                {
-                  "display-name": "",
-                  "display-value": "Vestri's Blind Spot Warning System with cross-traffic alert, is a driver assist feature that helps detect vehicles in blind spots during normal driving and traffic approaching from the sides when reversing out of parking spots.",
-                  "name": "DESCRIPTION",
-                  "value": "Vestri's Blind Spot Warning System with cross-traffic alert, is a driver assist feature that helps detect vehicles in blind spots during normal driving and traffic approaching from the sides when reversing out of parking spots."
-                }
-              ],
-              "display-name": "Blind Spot Warning",
-              "quantity": 1
-            }
-          ]
-        }
-      ],
-      "details": [
-        {
-          "display-name": "",
-          "display-value": "Step up to the next level by including everything in our V package and more, with our top of the line premium package.",
-          "name": "DESCRIPTION",
-          "value": "Step up to the next level by including everything in our V package and more, with our top of the line premium package."
-        }
-      ],
-      "display-name": "VE Trim Package"
-    }
-  ],
-  "_price": [
-    {
-      "self": {
-        "type": "prices.price-for-item",
-        "uri": "/prices/items/vestri_reference/qgqvhjjrhaydqny=",
-        "href": "http://reference.epdemos.com/cortex/prices/items/vestri_reference/qgqvhjjrhaydqny="
-      },
-      "messages": [],
-      "links": [],
-      "list-price": [
-        {
-          "amount": 477.36,
-          "currency": "CAD",
-          "display": "$477.36"
-        }
-      ],
-      "purchase-price": [
-        {
-          "amount": 477.36,
-          "currency": "CAD",
-          "display": "$477.36"
-        }
-      ]
-    }
-  ],
-  "_recommendations": [
-    {
-      "self": {
-        "type": "recommendations.item-recommendation-groups",
-        "uri": "/recommendations/items/vestri_reference/qgqvhjjrhaydqny=",
-        "href": "http://reference.epdemos.com/cortex/recommendations/items/vestri_reference/qgqvhjjrhaydqny="
-      },
-      "messages": [],
-      "links": [],
-      "_crosssell": [
-        {
-          "pagination": {
-            "current": 1,
-            "page-size": 5,
-            "pages": 1,
-            "results": 0,
-            "results-on-page": 0
-          }
-        }
-      ],
-      "_recommendation": [
-        {
-          "pagination": {
-            "current": 1,
-            "page-size": 5,
-            "pages": 1,
-            "results": 0,
-            "results-on-page": 0
-          }
-        }
-      ],
-      "_replacement": [
-        {
-          "pagination": {
-            "current": 1,
-            "page-size": 5,
-            "pages": 1,
-            "results": 0,
-            "results-on-page": 0
-          }
-        }
-      ],
-      "_upsell": [
-        {
-          "pagination": {
-            "current": 1,
-            "page-size": 5,
-            "pages": 1,
-            "results": 0,
-            "results-on-page": 0
-          }
-        }
-      ],
-      "_warranty": [
-        {
-          "pagination": {
-            "current": 1,
-            "page-size": 5,
-            "pages": 1,
-            "results": 0,
-            "results-on-page": 0
-          }
-        }
-      ]
-    }
-  ]
+	"self": {
+		"type": "elasticpath.collections.links",
+		"uri": "/?zoom=navigations:element,navigations:element:child,navigations:element:child:child,navigations:element:child:child:child,navigations:element:child:child:child:child,navigations:element:child:child:child:child:child,navigations:element:child:child:child:child:child:child,navigations:element:child:child:child:child:child:child:child,navigations:element:child:child:child:child:child:child:child:child",
+		"href": "https://vestri-us.epdemos.com/cortex/?zoom=navigations:element,navigations:element:child,navigations:element:child:child,navigations:element:child:child:child,navigations:element:child:child:child:child,navigations:element:child:child:child:child:child,navigations:element:child:child:child:child:child:child,navigations:element:child:child:child:child:child:child:child,navigations:element:child:child:child:child:child:child:child:child"
+	},
+	"messages": [],
+	"links": [{
+		"rel": "defaultcart",
+		"type": "carts.default-cart",
+		"uri": "/carts/vestri_b2c/default",
+		"href": "https://vestri-us.epdemos.com/cortex/carts/vestri_b2c/default"
+	}, {
+		"rel": "data-policies",
+		"type": "datapolicies.data-policies",
+		"uri": "/datapolicies/vestri_b2c",
+		"href": "https://vestri-us.epdemos.com/cortex/datapolicies/vestri_b2c"
+	}, {
+		"rel": "countries",
+		"type": "geographies.countries",
+		"uri": "/geographies/vestri_b2c/countries",
+		"href": "https://vestri-us.epdemos.com/cortex/geographies/vestri_b2c/countries"
+	}, {
+		"rel": "impersonationtokenform",
+		"type": "impersonation.token-form",
+		"uri": "/impersonation/vestri_b2c/form",
+		"href": "https://vestri-us.epdemos.com/cortex/impersonation/vestri_b2c/form"
+	}, {
+		"rel": "lookups",
+		"type": "lookups.lookups",
+		"uri": "/lookups/vestri_b2c",
+		"href": "https://vestri-us.epdemos.com/cortex/lookups/vestri_b2c"
+	}, {
+		"rel": "navigations",
+		"type": "navigations.navigations",
+		"uri": "/navigations/vestri_b2c",
+		"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+	}, {
+		"rel": "defaultprofile",
+		"type": "profiles.default-profile",
+		"uri": "/profiles/vestri_b2c/default",
+		"href": "https://vestri-us.epdemos.com/cortex/profiles/vestri_b2c/default"
+	}, {
+		"rel": "newaccountform",
+		"type": "registrations.new-account-registration-form",
+		"uri": "/registrations/vestri_b2c/newaccount/form",
+		"href": "https://vestri-us.epdemos.com/cortex/registrations/vestri_b2c/newaccount/form"
+	}, {
+		"rel": "searches",
+		"type": "searches.searches",
+		"uri": "/searches/vestri_b2c",
+		"href": "https://vestri-us.epdemos.com/cortex/searches/vestri_b2c"
+	}, {
+		"rel": "defaultwishlist",
+		"type": "wishlists.default-wishlist",
+		"uri": "/wishlists/vestri_b2c/default",
+		"href": "https://vestri-us.epdemos.com/cortex/wishlists/vestri_b2c/default"
+	}],
+	"_navigations": [{
+		"_element": [{
+			"self": {
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kzlf6vsfjbeugtcfkm=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzlf6vsfjbeugtcfkm="
+			},
+			"messages": [],
+			"links": [{
+				"rel": "top",
+				"type": "navigations.navigations",
+				"uri": "/navigations/vestri_b2c",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+			}, {
+				"rel": "offers",
+				"type": "offersearches.offer-search-result",
+				"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvnlfmx2wiveesq2mivj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1",
+				"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvnlfmx2wiveesq2mivj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1"
+			}, {
+				"rel": "items",
+				"type": "searches.navigation-search-result",
+				"uri": "/searches/navigations/vestri_b2c/kzlf6vsfjbeugtcfkm=/1",
+				"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kzlf6vsfjbeugtcfkm=/1"
+			}],
+			"display-name": "Vehicles",
+			"name": "VV_VEHICLES"
+		}, {
+			"self": {
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust="
+			},
+			"messages": [],
+			"links": [{
+				"rel": "top",
+				"type": "navigations.navigations",
+				"uri": "/navigations/vestri_b2c",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kziecx2difpu2q2mifjvg=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2difpu2q2mifjvg="
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kziecx2difpvqq2mifjvg=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2difpvqq2mifjvg="
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kziecx2uifpvinjq=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2uifpvinjq="
+			}, {
+				"rel": "offers",
+				"type": "offersearches.offer-search-result",
+				"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfxflfaqk7ineecushjfheox2bjzcf6qkeififirkskouxaylhmuwxg2l2mwrdema=/filters/qgqka=/1",
+				"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfxflfaqk7ineecushjfheox2bjzcf6qkeififirkskouxaylhmuwxg2l2mwrdema=/filters/qgqka=/1"
+			}, {
+				"rel": "items",
+				"type": "searches.navigation-search-result",
+				"uri": "/searches/navigations/vestri_b2c/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust=/1",
+				"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust=/1"
+			}],
+			"_child": [{
+				"self": {
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2difpu2q2mifjvg=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2difpu2q2mifjvg="
+				},
+				"messages": [],
+				"links": [{
+					"rel": "parent",
+					"rev": "child",
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust="
+				}, {
+					"rel": "top",
+					"type": "navigations.navigations",
+					"uri": "/navigations/vestri_b2c",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				}, {
+					"rel": "offers",
+					"type": "offersearches.offer-search-result",
+					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvvlfaqk7inav6tkdjravgu5jobqwozjnonuxuzncgiya=/filters/qgqka=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvvlfaqk7inav6tkdjravgu5jobqwozjnonuxuzncgiya=/filters/qgqka=/1"
+				}, {
+					"rel": "items",
+					"type": "searches.navigation-search-result",
+					"uri": "/searches/navigations/vestri_b2c/kziecx2difpu2q2mifjvg=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2difpu2q2mifjvg=/1"
+				}],
+				"display-name": "M-Class",
+				"name": "VPA_CA_MCLASS"
+			}, {
+				"self": {
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2difpvqq2mifjvg=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2difpvqq2mifjvg="
+				},
+				"messages": [],
+				"links": [{
+					"rel": "parent",
+					"rev": "child",
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust="
+				}, {
+					"rel": "top",
+					"type": "navigations.navigations",
+					"uri": "/navigations/vestri_b2c",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				}, {
+					"rel": "offers",
+					"type": "offersearches.offer-search-result",
+					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvvlfaqk7inav6wcdjravgu5jobqwozjnonuxuzncgiya=/filters/qgqka=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvvlfaqk7inav6wcdjravgu5jobqwozjnonuxuzncgiya=/filters/qgqka=/1"
+				}, {
+					"rel": "items",
+					"type": "searches.navigation-search-result",
+					"uri": "/searches/navigations/vestri_b2c/kziecx2difpvqq2mifjvg=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2difpvqq2mifjvg=/1"
+				}],
+				"display-name": "X-Class",
+				"name": "VPA_CA_XCLASS"
+			}, {
+				"self": {
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2uifpvinjq=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2uifpvinjq="
+				},
+				"messages": [],
+				"links": [{
+					"rel": "parent",
+					"rev": "child",
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust="
+				}, {
+					"rel": "top",
+					"type": "navigations.navigations",
+					"uri": "/navigations/vestri_b2c",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				}, {
+					"rel": "offers",
+					"type": "offersearches.offer-search-result",
+					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7krav6vbvgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7krav6vbvgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1"
+				}, {
+					"rel": "items",
+					"type": "searches.navigation-search-result",
+					"uri": "/searches/navigations/vestri_b2c/kziecx2uifpvinjq=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2uifpvinjq=/1"
+				}],
+				"display-name": "T50",
+				"name": "VPA_TA_T50"
+			}],
+			"display-name": "Charging and Adapters",
+			"name": "VPA_CHARGING_AND_ADAPTERS"
+		}, {
+			"self": {
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kzjv6q2iifjeoskoi5pvatcbjzjq=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzjv6q2iifjeoskoi5pvatcbjzjq="
+			},
+			"messages": [],
+			"links": [{
+				"rel": "top",
+				"type": "navigations.navigations",
+				"uri": "/navigations/vestri_b2c",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+			}, {
+				"rel": "offers",
+				"type": "offersearches.offer-search-result",
+				"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwflfgx2djbaver2jjzdv6ucmifhfhklqmftwklltnf5glirsga=/filters/qgqka=/1",
+				"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwflfgx2djbaver2jjzdv6ucmifhfhklqmftwklltnf5glirsga=/filters/qgqka=/1"
+			}, {
+				"rel": "items",
+				"type": "searches.navigation-search-result",
+				"uri": "/searches/navigations/vestri_b2c/kzjv6q2iifjeoskoi5pvatcbjzjq=/1",
+				"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kzjv6q2iifjeoskoi5pvatcbjzjq=/1"
+			}],
+			"display-name": "Charging Plans",
+			"name": "VS_CHARGING_PLANS"
+		}, {
+			"self": {
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kzcvgvcsjfpuetk7ifbugrktknhveskfkm=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpuetk7ifbugrktknhveskfkm="
+			},
+			"messages": [],
+			"links": [{
+				"rel": "top",
+				"type": "navigations.navigations",
+				"uri": "/navigations/vestri_b2c",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+			}, {
+				"rel": "offers",
+				"type": "offersearches.offer-search-result",
+				"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwvleku2ukjev6qsnl5augq2fknju6usjivj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1",
+				"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwvleku2ukjev6qsnl5augq2fknju6usjivj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1"
+			}, {
+				"rel": "items",
+				"type": "searches.navigation-search-result",
+				"uri": "/searches/navigations/vestri_b2c/kzcvgvcsjfpuetk7ifbugrktknhveskfkm=/1",
+				"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kzcvgvcsjfpuetk7ifbugrktknhveskfkm=/1"
+			}],
+			"display-name": "Accessories",
+			"name": "VESTRI_BM_ACCESSORIES"
+		}, {
+			"self": {
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kziecx2wiveesq2mivpucrcej5hfg=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wiveesq2mivpucrcej5hfg="
+			},
+			"messages": [],
+			"links": [{
+				"rel": "top",
+				"type": "navigations.navigations",
+				"uri": "/navigations/vestri_b2c",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kziecx2wifpu2q2mifjvg=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wifpu2q2mifjvg="
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kziecx2wifpvqq2mifjvg=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wifpvqq2mifjvg="
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kziecx2wifpvinjq=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wifpvinjq="
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kziecx2wifpuemjq=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wifpuemjq="
+			}, {
+				"rel": "offers",
+				"type": "offersearches.offer-search-result",
+				"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwjlfaqk7kzcuqskdjrcv6qkeirhu4u5jobqwozjnonuxuzncgiya=/filters/qgqka=/1",
+				"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwjlfaqk7kzcuqskdjrcv6qkeirhu4u5jobqwozjnonuxuzncgiya=/filters/qgqka=/1"
+			}, {
+				"rel": "items",
+				"type": "searches.navigation-search-result",
+				"uri": "/searches/navigations/vestri_b2c/kziecx2wiveesq2mivpucrcej5hfg=/1",
+				"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2wiveesq2mivpucrcej5hfg=/1"
+			}],
+			"_child": [{
+				"self": {
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2wifpu2q2mifjvg=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wifpu2q2mifjvg="
+				},
+				"messages": [],
+				"links": [{
+					"rel": "parent",
+					"rev": "child",
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2wiveesq2mivpucrcej5hfg=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wiveesq2mivpucrcej5hfg="
+				}, {
+					"rel": "top",
+					"type": "navigations.navigations",
+					"uri": "/navigations/vestri_b2c",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				}, {
+					"rel": "offers",
+					"type": "offersearches.offer-search-result",
+					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvvlfaqk7kzav6tkdjravgu5jobqwozjnonuxuzncgiya=/filters/qgqka=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvvlfaqk7kzav6tkdjravgu5jobqwozjnonuxuzncgiya=/filters/qgqka=/1"
+				}, {
+					"rel": "items",
+					"type": "searches.navigation-search-result",
+					"uri": "/searches/navigations/vestri_b2c/kziecx2wifpu2q2mifjvg=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2wifpu2q2mifjvg=/1"
+				}],
+				"display-name": "M-Class",
+				"name": "VPA_VA_MCLASS"
+			}, {
+				"self": {
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2wifpvqq2mifjvg=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wifpvqq2mifjvg="
+				},
+				"messages": [],
+				"links": [{
+					"rel": "parent",
+					"rev": "child",
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2wiveesq2mivpucrcej5hfg=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wiveesq2mivpucrcej5hfg="
+				}, {
+					"rel": "top",
+					"type": "navigations.navigations",
+					"uri": "/navigations/vestri_b2c",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				}, {
+					"rel": "offers",
+					"type": "offersearches.offer-search-result",
+					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvvlfaqk7kzav6wcdjravgu5jobqwozjnonuxuzncgiya=/filters/qgqka=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvvlfaqk7kzav6wcdjravgu5jobqwozjnonuxuzncgiya=/filters/qgqka=/1"
+				}, {
+					"rel": "items",
+					"type": "searches.navigation-search-result",
+					"uri": "/searches/navigations/vestri_b2c/kziecx2wifpvqq2mifjvg=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2wifpvqq2mifjvg=/1"
+				}],
+				"display-name": "X-Class",
+				"name": "VPA_VA_XCLASS"
+			}, {
+				"self": {
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2wifpvinjq=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wifpvinjq="
+				},
+				"messages": [],
+				"links": [{
+					"rel": "parent",
+					"rev": "child",
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2wiveesq2mivpucrcej5hfg=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wiveesq2mivpucrcej5hfg="
+				}, {
+					"rel": "top",
+					"type": "navigations.navigations",
+					"uri": "/navigations/vestri_b2c",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				}, {
+					"rel": "offers",
+					"type": "offersearches.offer-search-result",
+					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7kzav6vbvgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7kzav6vbvgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1"
+				}, {
+					"rel": "items",
+					"type": "searches.navigation-search-result",
+					"uri": "/searches/navigations/vestri_b2c/kziecx2wifpvinjq=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2wifpvinjq=/1"
+				}],
+				"display-name": "T50",
+				"name": "VPA_VA_T50"
+			}, {
+				"self": {
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2wifpuemjq=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wifpuemjq="
+				},
+				"messages": [],
+				"links": [{
+					"rel": "parent",
+					"rev": "child",
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2wiveesq2mivpucrcej5hfg=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wiveesq2mivpucrcej5hfg="
+				}, {
+					"rel": "top",
+					"type": "navigations.navigations",
+					"uri": "/navigations/vestri_b2c",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				}, {
+					"rel": "offers",
+					"type": "offersearches.offer-search-result",
+					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7kzav6qrrgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7kzav6qrrgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1"
+				}, {
+					"rel": "items",
+					"type": "searches.navigation-search-result",
+					"uri": "/searches/navigations/vestri_b2c/kziecx2wifpuemjq=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2wifpuemjq=/1"
+				}],
+				"display-name": "B10",
+				"name": "VPA_VA_B10"
+			}],
+			"display-name": "Vehicle Addons",
+			"name": "VPA_VEHICLE_ADDONS"
+		}, {
+			"self": {
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kzcvgvcsjfpuetk7ififaqksivga=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpuetk7ififaqksivga="
+			},
+			"messages": [],
+			"links": [{
+				"rel": "top",
+				"type": "navigations.navigations",
+				"uri": "/navigations/vestri_b2c",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jvcu4uy=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jvcu4uy="
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7k5hu2rkokm=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7k5hu2rkokm="
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jneuiuy=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jneuiuy="
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jvbuyqktkm=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jvbuyqktkm="
+			}, {
+				"rel": "offers",
+				"type": "offersearches.offer-search-result",
+				"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwfleku2ukjev6qsnl5avaucbkjcuzklqmftwklltnf5glirsga=/filters/qgqka=/1",
+				"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwfleku2ukjev6qsnl5avaucbkjcuzklqmftwklltnf5glirsga=/filters/qgqka=/1"
+			}, {
+				"rel": "items",
+				"type": "searches.navigation-search-result",
+				"uri": "/searches/navigations/vestri_b2c/kzcvgvcsjfpuetk7ififaqksivga=/1",
+				"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kzcvgvcsjfpuetk7ififaqksivga=/1"
+			}],
+			"_child": [{
+				"self": {
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jvcu4uy=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jvcu4uy="
+				},
+				"messages": [],
+				"links": [{
+					"rel": "parent",
+					"rev": "child",
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kzcvgvcsjfpuetk7ififaqksivga=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpuetk7ififaqksivga="
+				}, {
+					"rel": "top",
+					"type": "navigations.navigations",
+					"uri": "/navigations/vestri_b2c",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				}, {
+					"rel": "featuredoffers",
+					"rev": "navigation",
+					"type": "offersearches.featured-offers",
+					"uri": "/offersearches/vestri_b2c/featuredoffers/kzcvgvcsjfpucucqifjektc7jvcu4uy=",
+					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/featuredoffers/kzcvgvcsjfpucucqifjektc7jvcu4uy="
+				}, {
+					"rel": "offers",
+					"type": "offersearches.offer-search-result",
+					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwnleku2ukjev6qkqkbaverkml5guktstvfygcz3ffvzws6tfuizda=/filters/qgqka=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwnleku2ukjev6qkqkbaverkml5guktstvfygcz3ffvzws6tfuizda=/filters/qgqka=/1"
+				}, {
+					"rel": "items",
+					"type": "searches.navigation-search-result",
+					"uri": "/searches/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jvcu4uy=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jvcu4uy=/1"
+				}],
+				"display-name": "Mens",
+				"name": "VESTRI_APPAREL_MENS"
+			}, {
+				"self": {
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7k5hu2rkokm=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7k5hu2rkokm="
+				},
+				"messages": [],
+				"links": [{
+					"rel": "parent",
+					"rev": "child",
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kzcvgvcsjfpuetk7ififaqksivga=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpuetk7ififaqksivga="
+				}, {
+					"rel": "top",
+					"type": "navigations.navigations",
+					"uri": "/navigations/vestri_b2c",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				}, {
+					"rel": "offers",
+					"type": "offersearches.offer-search-result",
+					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwvleku2ukjev6qkqkbaverkml5lu6tkfjzj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwvleku2ukjev6qkqkbaverkml5lu6tkfjzj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1"
+				}, {
+					"rel": "items",
+					"type": "searches.navigation-search-result",
+					"uri": "/searches/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7k5hu2rkokm=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7k5hu2rkokm=/1"
+				}],
+				"display-name": "Womens",
+				"name": "VESTRI_APPAREL_WOMENS"
+			}, {
+				"self": {
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jneuiuy=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jneuiuy="
+				},
+				"messages": [],
+				"links": [{
+					"rel": "parent",
+					"rev": "child",
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kzcvgvcsjfpuetk7ififaqksivga=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpuetk7ififaqksivga="
+				}, {
+					"rel": "top",
+					"type": "navigations.navigations",
+					"uri": "/navigations/vestri_b2c",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				}, {
+					"rel": "offers",
+					"type": "offersearches.offer-search-result",
+					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwnleku2ukjev6qkqkbaverkml5fusrctvfygcz3ffvzws6tfuizda=/filters/qgqka=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwnleku2ukjev6qkqkbaverkml5fusrctvfygcz3ffvzws6tfuizda=/filters/qgqka=/1"
+				}, {
+					"rel": "items",
+					"type": "searches.navigation-search-result",
+					"uri": "/searches/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jneuiuy=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jneuiuy=/1"
+				}],
+				"display-name": "Kids",
+				"name": "VESTRI_APPAREL_KIDS"
+			}, {
+				"self": {
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jvbuyqktkm=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jvbuyqktkm="
+				},
+				"messages": [],
+				"links": [{
+					"rel": "parent",
+					"rev": "child",
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kzcvgvcsjfpuetk7ififaqksivga=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpuetk7ififaqksivga="
+				}, {
+					"rel": "top",
+					"type": "navigations.navigations",
+					"uri": "/navigations/vestri_b2c",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				}, {
+					"rel": "offers",
+					"type": "offersearches.offer-search-result",
+					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwvleku2ukjev6qkqkbaverkml5gugtcbknj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwvleku2ukjev6qkqkbaverkml5gugtcbknj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1"
+				}, {
+					"rel": "items",
+					"type": "searches.navigation-search-result",
+					"uri": "/searches/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jvbuyqktkm=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jvbuyqktkm=/1"
+				}],
+				"display-name": "M-Class",
+				"name": "VESTRI_APPAREL_MCLASS"
+			}],
+			"display-name": "Apparel",
+			"name": "VESTRI_BM_APPAREL"
+		}, {
+			"self": {
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kzjv6qkojzkuctc7jfhfgucfinkest2okm=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzjv6qkojzkuctc7jfhfgucfinkest2okm="
+			},
+			"messages": [],
+			"links": [{
+				"rel": "top",
+				"type": "navigations.navigations",
+				"uri": "/navigations/vestri_b2c",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+			}, {
+				"rel": "offers",
+				"type": "offersearches.offer-search-result",
+				"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwvlfgx2bjzhfkqkml5eu4u2qivbviskpjzj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1",
+				"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwvlfgx2bjzhfkqkml5eu4u2qivbviskpjzj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1"
+			}, {
+				"rel": "items",
+				"type": "searches.navigation-search-result",
+				"uri": "/searches/navigations/vestri_b2c/kzjv6qkojzkuctc7jfhfgucfinkest2okm=/1",
+				"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kzjv6qkojzkuctc7jfhfgucfinkest2okm=/1"
+			}],
+			"display-name": "Annual Inspections",
+			"name": "VS_ANNUAL_INSPECTIONS"
+		}, {
+			"self": {
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kzlf6vsfjbeugtcfl5hvavcjj5hfg=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzlf6vsfjbeugtcfl5hvavcjj5hfg="
+			},
+			"messages": [],
+			"links": [{
+				"rel": "top",
+				"type": "navigations.navigations",
+				"uri": "/navigations/vestri_b2c",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+			}, {
+				"rel": "offers",
+				"type": "offersearches.offer-search-result",
+				"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwjlfmx2wiveesq2mivpu6ucujfhu4u5jobqwozjnonuxuzncgiya=/filters/qgqka=/1",
+				"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwjlfmx2wiveesq2mivpu6ucujfhu4u5jobqwozjnonuxuzncgiya=/filters/qgqka=/1"
+			}, {
+				"rel": "items",
+				"type": "searches.navigation-search-result",
+				"uri": "/searches/navigations/vestri_b2c/kzlf6vsfjbeugtcfl5hvavcjj5hfg=/1",
+				"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kzlf6vsfjbeugtcfl5hvavcjj5hfg=/1"
+			}],
+			"display-name": "Vehicle Options",
+			"name": "VV_VEHICLE_OPTIONS"
+		}, {
+			"self": {
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy="
+			},
+			"messages": [],
+			"links": [{
+				"rel": "top",
+				"type": "navigations.navigations",
+				"uri": "/navigations/vestri_b2c",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kziecx2nkbpvatcbjzhekrc7jvaustsfjzkectsdiu=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2nkbpvatcbjzhekrc7jvaustsfjzkectsdiu="
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kziecx2nkbpvinjq=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2nkbpvinjq="
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kziecx2nkbpuemjq=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2nkbpuemjq="
+			}, {
+				"rel": "offers",
+				"type": "offersearches.offer-search-result",
+				"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfxblfaqk7jvaustsuivhectsdivpvauspirkugvctvfygcz3ffvzws6tfuizda=/filters/qgqka=/1",
+				"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfxblfaqk7jvaustsuivhectsdivpvauspirkugvctvfygcz3ffvzws6tfuizda=/filters/qgqka=/1"
+			}, {
+				"rel": "items",
+				"type": "searches.navigation-search-result",
+				"uri": "/searches/navigations/vestri_b2c/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy=/1",
+				"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy=/1"
+			}],
+			"_child": [{
+				"self": {
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2nkbpvatcbjzhekrc7jvaustsfjzkectsdiu=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2nkbpvatcbjzhekrc7jvaustsfjzkectsdiu="
+				},
+				"messages": [],
+				"links": [{
+					"rel": "parent",
+					"rev": "child",
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy="
+				}, {
+					"rel": "top",
+					"type": "navigations.navigations",
+					"uri": "/navigations/vestri_b2c",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				}, {
+					"rel": "offers",
+					"type": "offersearches.offer-search-result",
+					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfxjlfaqk7jvif6ucmifhe4rkel5gucskoivhfiqkoinc2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfxjlfaqk7jvif6ucmifhe4rkel5gucskoivhfiqkoinc2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1"
+				}, {
+					"rel": "items",
+					"type": "searches.navigation-search-result",
+					"uri": "/searches/navigations/vestri_b2c/kziecx2nkbpvatcbjzhekrc7jvaustsfjzkectsdiu=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2nkbpvatcbjzhekrc7jvaustsfjzkectsdiu=/1"
+				}],
+				"display-name": "Planned Maintenance Kits",
+				"name": "VPA_MP_PLANNED_MAINENTANCE"
+			}, {
+				"self": {
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2nkbpvinjq=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2nkbpvinjq="
+				},
+				"messages": [],
+				"links": [{
+					"rel": "parent",
+					"rev": "child",
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy="
+				}, {
+					"rel": "top",
+					"type": "navigations.navigations",
+					"uri": "/navigations/vestri_b2c",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				}, {
+					"rel": "offers",
+					"type": "offersearches.offer-search-result",
+					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7jvif6vbvgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7jvif6vbvgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1"
+				}, {
+					"rel": "items",
+					"type": "searches.navigation-search-result",
+					"uri": "/searches/navigations/vestri_b2c/kziecx2nkbpvinjq=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2nkbpvinjq=/1"
+				}],
+				"display-name": "T50",
+				"name": "VPA_MP_T50"
+			}, {
+				"self": {
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2nkbpuemjq=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2nkbpuemjq="
+				},
+				"messages": [],
+				"links": [{
+					"rel": "parent",
+					"rev": "child",
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy="
+				}, {
+					"rel": "top",
+					"type": "navigations.navigations",
+					"uri": "/navigations/vestri_b2c",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				}, {
+					"rel": "offers",
+					"type": "offersearches.offer-search-result",
+					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7jvif6qrrgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7jvif6qrrgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1"
+				}, {
+					"rel": "items",
+					"type": "searches.navigation-search-result",
+					"uri": "/searches/navigations/vestri_b2c/kziecx2nkbpuemjq=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2nkbpuemjq=/1"
+				}],
+				"display-name": "B10",
+				"name": "VPA_MP_B10"
+			}],
+			"display-name": "Maintenance Products",
+			"name": "VPA_MAINTENANCE_PRODUCTS"
+		}, {
+			"self": {
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kzlf6vcsjfgv6ucbinfucr2fkm=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzlf6vcsjfgv6ucbinfucr2fkm="
+			},
+			"messages": [],
+			"links": [{
+				"rel": "top",
+				"type": "navigations.navigations",
+				"uri": "/navigations/vestri_b2c",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+			}, {
+				"rel": "offers",
+				"type": "offersearches.offer-search-result",
+				"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwblfmx2ukjeu2x2qifbuwqkhivj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1",
+				"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwblfmx2ukjeu2x2qifbuwqkhivj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1"
+			}, {
+				"rel": "items",
+				"type": "searches.navigation-search-result",
+				"uri": "/searches/navigations/vestri_b2c/kzlf6vcsjfgv6ucbinfucr2fkm=/1",
+				"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kzlf6vcsjfgv6ucbinfucr2fkm=/1"
+			}],
+			"display-name": "Vehicle Trim Packages",
+			"name": "VV_TRIM_PACKAGES"
+		}, {
+			"self": {
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kziecx2ujfjekuy=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ujfjekuy="
+			},
+			"messages": [],
+			"links": [{
+				"rel": "top",
+				"type": "navigations.navigations",
+				"uri": "/navigations/vestri_b2c",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kziecx2ul5gugtcbknjq=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ul5gugtcbknjq="
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kziecx2ul5megtcbknjq=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ul5megtcbknjq="
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kziecx2ul5kdkma=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ul5kdkma="
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kziecx2ul5gusq2iivgestq=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ul5gusq2iivgestq="
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_b2c/kziecx2ul5ke6s2pjbau2qi=",
+				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ul5ke6s2pjbau2qi="
+			}, {
+				"rel": "offers",
+				"type": "offersearches.offer-search-result",
+				"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvflfaqk7kreverktvfygcz3ffvzws6tfuizda=/filters/qgqka=/1",
+				"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvflfaqk7kreverktvfygcz3ffvzws6tfuizda=/filters/qgqka=/1"
+			}, {
+				"rel": "items",
+				"type": "searches.navigation-search-result",
+				"uri": "/searches/navigations/vestri_b2c/kziecx2ujfjekuy=/1",
+				"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2ujfjekuy=/1"
+			}],
+			"_child": [{
+				"self": {
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2ul5gugtcbknjq=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ul5gugtcbknjq="
+				},
+				"messages": [],
+				"links": [{
+					"rel": "parent",
+					"rev": "child",
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2ujfjekuy=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ujfjekuy="
+				}, {
+					"rel": "top",
+					"type": "navigations.navigations",
+					"uri": "/navigations/vestri_b2c",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				}, {
+					"rel": "offers",
+					"type": "offersearches.offer-search-result",
+					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvrlfaqk7krpu2q2mifjvhklqmftwklltnf5glirsga=/filters/qgqka=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvrlfaqk7krpu2q2mifjvhklqmftwklltnf5glirsga=/filters/qgqka=/1"
+				}, {
+					"rel": "items",
+					"type": "searches.navigation-search-result",
+					"uri": "/searches/navigations/vestri_b2c/kziecx2ul5gugtcbknjq=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2ul5gugtcbknjq=/1"
+				}],
+				"display-name": "M-Class",
+				"name": "VPA_T_MCLASS"
+			}, {
+				"self": {
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2ul5megtcbknjq=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ul5megtcbknjq="
+				},
+				"messages": [],
+				"links": [{
+					"rel": "parent",
+					"rev": "child",
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2ujfjekuy=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ujfjekuy="
+				}, {
+					"rel": "top",
+					"type": "navigations.navigations",
+					"uri": "/navigations/vestri_b2c",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				}, {
+					"rel": "offers",
+					"type": "offersearches.offer-search-result",
+					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvrlfaqk7krpvqq2mifjvhklqmftwklltnf5glirsga=/filters/qgqka=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvrlfaqk7krpvqq2mifjvhklqmftwklltnf5glirsga=/filters/qgqka=/1"
+				}, {
+					"rel": "items",
+					"type": "searches.navigation-search-result",
+					"uri": "/searches/navigations/vestri_b2c/kziecx2ul5megtcbknjq=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2ul5megtcbknjq=/1"
+				}],
+				"display-name": "X-Class",
+				"name": "VPA_T_XCLASS"
+			}, {
+				"self": {
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2ul5kdkma=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ul5kdkma="
+				},
+				"messages": [],
+				"links": [{
+					"rel": "parent",
+					"rev": "child",
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2ujfjekuy=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ujfjekuy="
+				}, {
+					"rel": "top",
+					"type": "navigations.navigations",
+					"uri": "/navigations/vestri_b2c",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				}, {
+					"rel": "offers",
+					"type": "offersearches.offer-search-result",
+					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvflfaqk7krpvinjqvfygcz3ffvzws6tfuizda=/filters/qgqka=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvflfaqk7krpvinjqvfygcz3ffvzws6tfuizda=/filters/qgqka=/1"
+				}, {
+					"rel": "items",
+					"type": "searches.navigation-search-result",
+					"uri": "/searches/navigations/vestri_b2c/kziecx2ul5kdkma=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2ul5kdkma=/1"
+				}],
+				"display-name": "T50",
+				"name": "VPA_T_T50"
+			}, {
+				"self": {
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2ul5gusq2iivgestq=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ul5gusq2iivgestq="
+				},
+				"messages": [],
+				"links": [{
+					"rel": "parent",
+					"rev": "child",
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2ujfjekuy=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ujfjekuy="
+				}, {
+					"rel": "top",
+					"type": "navigations.navigations",
+					"uri": "/navigations/vestri_b2c",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				}, {
+					"rel": "offers",
+					"type": "offersearches.offer-search-result",
+					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvzlfaqk7krpu2skdjbcuyskovfygcz3ffvzws6tfuizda=/filters/qgqka=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvzlfaqk7krpu2skdjbcuyskovfygcz3ffvzws6tfuizda=/filters/qgqka=/1"
+				}, {
+					"rel": "items",
+					"type": "searches.navigation-search-result",
+					"uri": "/searches/navigations/vestri_b2c/kziecx2ul5gusq2iivgestq=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2ul5gusq2iivgestq=/1"
+				}],
+				"display-name": "Michelin",
+				"name": "VPA_T_MICHELIN"
+			}, {
+				"self": {
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2ul5ke6s2pjbau2qi=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ul5ke6s2pjbau2qi="
+				},
+				"messages": [],
+				"links": [{
+					"rel": "parent",
+					"rev": "child",
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_b2c/kziecx2ujfjekuy=",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ujfjekuy="
+				}, {
+					"rel": "top",
+					"type": "navigations.navigations",
+					"uri": "/navigations/vestri_b2c",
+					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				}, {
+					"rel": "offers",
+					"type": "offersearches.offer-search-result",
+					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvzlfaqk7krpvit2lj5eectkbvfygcz3ffvzws6tfuizda=/filters/qgqka=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvzlfaqk7krpvit2lj5eectkbvfygcz3ffvzws6tfuizda=/filters/qgqka=/1"
+				}, {
+					"rel": "items",
+					"type": "searches.navigation-search-result",
+					"uri": "/searches/navigations/vestri_b2c/kziecx2ul5ke6s2pjbau2qi=/1",
+					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2ul5ke6s2pjbau2qi=/1"
+				}],
+				"display-name": "Yokohama",
+				"name": "VPA_T_TOKOHAMA"
+			}],
+			"display-name": "Tires",
+			"name": "VPA_TIRES"
+		}]
+	}]
 }

--- a/components/src/AppHeaderNavigation/appheadernavigation.main.api.mocks.tsx
+++ b/components/src/AppHeaderNavigation/appheadernavigation.main.api.mocks.tsx
@@ -1,0 +1,43 @@
+/**
+ * Copyright © 2019 Elastic Path Software Inc. All rights reserved.
+ *
+ * This is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this license. If not, see
+ *
+ *     https://www.gnu.org/licenses/
+ *
+ *
+ */
+import fetchMock from 'fetch-mock/es5/client';
+import fetchNavigationDataResponse from './MockHttpResponses/navigation_data_response.json';
+import loginResponse from '../CommonMockHttpResponses/login_response.json';
+
+function mockMultiCartResponse(mockObj) {
+  mockObj.get(
+    '/cortex/?zoom=navigations:element,navigations:element:child,navigations:element:child:child,navigations:element:child:child:child,navigations:element:child:child:child:child,navigations:element:child:child:child:child:child,navigations:element:child:child:child:child:child:child,navigations:element:child:child:child:child:child:child:child,navigations:element:child:child:child:child:child:child:child:child',
+    fetchNavigationDataResponse,
+  );
+}
+
+function mockLoginResponse(mockObj) {
+  mockObj.post(
+    '/cortex/oauth2/tokens',
+    loginResponse,
+  );
+}
+
+export function mockFetchNavigationData() {
+  fetchMock.restore();
+  mockLoginResponse(fetchMock);
+  mockMultiCartResponse(fetchMock);
+}

--- a/components/src/AppHeaderNavigation/appheadernavigation.main.stories.tsx
+++ b/components/src/AppHeaderNavigation/appheadernavigation.main.stories.tsx
@@ -24,6 +24,7 @@ import { storiesOf } from '@storybook/react';
 import { MemoryRouter } from 'react-router';
 import { text, object } from "@storybook/addon-knobs/react";
 import { textToFunc } from "../../../storybook/utils/storybookUtils"
+import { mockFetchNavigationData } from './appheadernavigation.main.api.mocks';
 
 import AppHeaderNavigationMain from './appheadernavigation.main';
 import { boolean } from '@storybook/addon-knobs';
@@ -36,6 +37,7 @@ storiesOf('Components|AppHeaderNavigationMain', module)
     },
   })
   .add('AppHeaderNavigationMain', () => {
+    mockFetchNavigationData();
     
     let isOfflineCheckFuncText = text('isOfflineCheck','() => {alert("isOfflineCheck invoked")}');
     let onFetchNavigationErrorFuncText = text('onFetchNavigationError','() => {alert("onFetchNavigationError invoked")}');


### PR DESCRIPTION
Description:
<!--A brief description of changes. Things to include: WIP? Dependent PR's opened against other tickets? -->

#494 

AppHeaderNavigation component did not show up in storybook due to requests to cortex not being mocked.  

This issue is resolved with this PR

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Component Updates:
<!--Have you updated components/package.json and components/package-lock.json for any components that have been updated? -->
- [ ] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests

Navigate to AppHeaderNavigation and check that the appheadernavigation now shoes up properly.

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
