### PR TITLE
Alter the mock data to use reference.elasticpath.com

### DIFF
--- a/components/src/AppHeaderNavigation/MockHttpResponses/navigation_data_response.json
+++ b/components/src/AppHeaderNavigation/MockHttpResponses/navigation_data_response.json
@@ -2,217 +2,267 @@
 	"self": {
 		"type": "elasticpath.collections.links",
 		"uri": "/?zoom=navigations:element,navigations:element:child,navigations:element:child:child,navigations:element:child:child:child,navigations:element:child:child:child:child,navigations:element:child:child:child:child:child,navigations:element:child:child:child:child:child:child,navigations:element:child:child:child:child:child:child:child,navigations:element:child:child:child:child:child:child:child:child",
-		"href": "https://vestri-us.epdemos.com/cortex/?zoom=navigations:element,navigations:element:child,navigations:element:child:child,navigations:element:child:child:child,navigations:element:child:child:child:child,navigations:element:child:child:child:child:child,navigations:element:child:child:child:child:child:child,navigations:element:child:child:child:child:child:child:child,navigations:element:child:child:child:child:child:child:child:child"
+		"href": "http://reference.epdemos.com/cortex/?zoom=navigations:element,navigations:element:child,navigations:element:child:child,navigations:element:child:child:child,navigations:element:child:child:child:child,navigations:element:child:child:child:child:child,navigations:element:child:child:child:child:child:child,navigations:element:child:child:child:child:child:child:child,navigations:element:child:child:child:child:child:child:child:child"
 	},
 	"messages": [],
 	"links": [{
 		"rel": "defaultcart",
 		"type": "carts.default-cart",
-		"uri": "/carts/vestri_b2c/default",
-		"href": "https://vestri-us.epdemos.com/cortex/carts/vestri_b2c/default"
+		"uri": "/carts/vestri_reference/default",
+		"href": "http://reference.epdemos.com/cortex/carts/vestri_reference/default"
 	}, {
 		"rel": "data-policies",
 		"type": "datapolicies.data-policies",
-		"uri": "/datapolicies/vestri_b2c",
-		"href": "https://vestri-us.epdemos.com/cortex/datapolicies/vestri_b2c"
+		"uri": "/datapolicies/vestri_reference",
+		"href": "http://reference.epdemos.com/cortex/datapolicies/vestri_reference"
 	}, {
 		"rel": "countries",
 		"type": "geographies.countries",
-		"uri": "/geographies/vestri_b2c/countries",
-		"href": "https://vestri-us.epdemos.com/cortex/geographies/vestri_b2c/countries"
-	}, {
-		"rel": "impersonationtokenform",
-		"type": "impersonation.token-form",
-		"uri": "/impersonation/vestri_b2c/form",
-		"href": "https://vestri-us.epdemos.com/cortex/impersonation/vestri_b2c/form"
+		"uri": "/geographies/vestri_reference/countries",
+		"href": "http://reference.epdemos.com/cortex/geographies/vestri_reference/countries"
 	}, {
 		"rel": "lookups",
 		"type": "lookups.lookups",
-		"uri": "/lookups/vestri_b2c",
-		"href": "https://vestri-us.epdemos.com/cortex/lookups/vestri_b2c"
+		"uri": "/lookups/vestri_reference",
+		"href": "http://reference.epdemos.com/cortex/lookups/vestri_reference"
 	}, {
 		"rel": "navigations",
 		"type": "navigations.navigations",
-		"uri": "/navigations/vestri_b2c",
-		"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+		"uri": "/navigations/vestri_reference",
+		"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
 	}, {
 		"rel": "defaultprofile",
 		"type": "profiles.default-profile",
-		"uri": "/profiles/vestri_b2c/default",
-		"href": "https://vestri-us.epdemos.com/cortex/profiles/vestri_b2c/default"
+		"uri": "/profiles/vestri_reference/default",
+		"href": "http://reference.epdemos.com/cortex/profiles/vestri_reference/default"
 	}, {
 		"rel": "newaccountform",
 		"type": "registrations.new-account-registration-form",
-		"uri": "/registrations/vestri_b2c/newaccount/form",
-		"href": "https://vestri-us.epdemos.com/cortex/registrations/vestri_b2c/newaccount/form"
+		"uri": "/registrations/vestri_reference/newaccount/form",
+		"href": "http://reference.epdemos.com/cortex/registrations/vestri_reference/newaccount/form"
 	}, {
 		"rel": "searches",
 		"type": "searches.searches",
-		"uri": "/searches/vestri_b2c",
-		"href": "https://vestri-us.epdemos.com/cortex/searches/vestri_b2c"
+		"uri": "/searches/vestri_reference",
+		"href": "http://reference.epdemos.com/cortex/searches/vestri_reference"
 	}, {
 		"rel": "defaultwishlist",
 		"type": "wishlists.default-wishlist",
-		"uri": "/wishlists/vestri_b2c/default",
-		"href": "https://vestri-us.epdemos.com/cortex/wishlists/vestri_b2c/default"
+		"uri": "/wishlists/vestri_reference/default",
+		"href": "http://reference.epdemos.com/cortex/wishlists/vestri_reference/default"
 	}],
 	"_navigations": [{
 		"_element": [{
 			"self": {
 				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kzlf6vsfjbeugtcfkm=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzlf6vsfjbeugtcfkm="
+				"uri": "/navigations/vestri_reference/kzlf6vsfjbeugtcfkm=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kzlf6vsfjbeugtcfkm="
 			},
 			"messages": [],
 			"links": [{
 				"rel": "top",
 				"type": "navigations.navigations",
-				"uri": "/navigations/vestri_b2c",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				"uri": "/navigations/vestri_reference",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
+			}, {
+				"rel": "featuredoffers",
+				"rev": "navigation",
+				"type": "offersearches.featured-offers",
+				"uri": "/offersearches/vestri_reference/featuredoffers/kzlf6vsfjbeugtcfkm=",
+				"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/featuredoffers/kzlf6vsfjbeugtcfkm="
 			}, {
 				"rel": "offers",
 				"type": "offersearches.offer-search-result",
-				"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvnlfmx2wiveesq2mivj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1",
-				"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvnlfmx2wiveesq2mivj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1"
+				"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvnlfmx2wiveesq2mivj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1",
+				"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvnlfmx2wiveesq2mivj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1"
 			}, {
 				"rel": "items",
 				"type": "searches.navigation-search-result",
-				"uri": "/searches/navigations/vestri_b2c/kzlf6vsfjbeugtcfkm=/1",
-				"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kzlf6vsfjbeugtcfkm=/1"
+				"uri": "/searches/navigations/vestri_reference/kzlf6vsfjbeugtcfkm=/1",
+				"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kzlf6vsfjbeugtcfkm=/1"
 			}],
 			"display-name": "Vehicles",
 			"name": "VV_VEHICLES"
 		}, {
 			"self": {
 				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust="
+				"uri": "/navigations/vestri_reference/kzjv6q2iifjeoskoi5pvatcbjzjq=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kzjv6q2iifjeoskoi5pvatcbjzjq="
 			},
 			"messages": [],
 			"links": [{
 				"rel": "top",
 				"type": "navigations.navigations",
-				"uri": "/navigations/vestri_b2c",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				"uri": "/navigations/vestri_reference",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
 			}, {
-				"rel": "child",
-				"rev": "parent",
-				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kziecx2difpu2q2mifjvg=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2difpu2q2mifjvg="
-			}, {
-				"rel": "child",
-				"rev": "parent",
-				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kziecx2difpvqq2mifjvg=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2difpvqq2mifjvg="
-			}, {
-				"rel": "child",
-				"rev": "parent",
-				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kziecx2uifpvinjq=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2uifpvinjq="
+				"rel": "featuredoffers",
+				"rev": "navigation",
+				"type": "offersearches.featured-offers",
+				"uri": "/offersearches/vestri_reference/featuredoffers/kzjv6q2iifjeoskoi5pvatcbjzjq=",
+				"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/featuredoffers/kzjv6q2iifjeoskoi5pvatcbjzjq="
 			}, {
 				"rel": "offers",
 				"type": "offersearches.offer-search-result",
-				"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfxflfaqk7ineecushjfheox2bjzcf6qkeififirkskouxaylhmuwxg2l2mwrdema=/filters/qgqka=/1",
-				"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfxflfaqk7ineecushjfheox2bjzcf6qkeififirkskouxaylhmuwxg2l2mwrdema=/filters/qgqka=/1"
+				"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfwflfgx2djbaver2jjzdv6ucmifhfhklqmftwklltnf5glirsga=/filters/qgqka=/1",
+				"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfwflfgx2djbaver2jjzdv6ucmifhfhklqmftwklltnf5glirsga=/filters/qgqka=/1"
 			}, {
 				"rel": "items",
 				"type": "searches.navigation-search-result",
-				"uri": "/searches/navigations/vestri_b2c/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust=/1",
-				"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust=/1"
+				"uri": "/searches/navigations/vestri_reference/kzjv6q2iifjeoskoi5pvatcbjzjq=/1",
+				"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kzjv6q2iifjeoskoi5pvatcbjzjq=/1"
+			}],
+			"display-name": "Charging Plans",
+			"name": "VS_CHARGING_PLANS"
+		}, {
+			"self": {
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_reference/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust="
+			},
+			"messages": [],
+			"links": [{
+				"rel": "top",
+				"type": "navigations.navigations",
+				"uri": "/navigations/vestri_reference",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_reference/kziecx2difpu2q2mifjvg=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2difpu2q2mifjvg="
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_reference/kziecx2difpvqq2mifjvg=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2difpvqq2mifjvg="
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_reference/kziecx2uifpvinjq=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2uifpvinjq="
+			}, {
+				"rel": "offers",
+				"type": "offersearches.offer-search-result",
+				"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfxflfaqk7ineecushjfheox2bjzcf6qkeififirkskouxaylhmuwxg2l2mwrdema=/filters/qgqka=/1",
+				"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfxflfaqk7ineecushjfheox2bjzcf6qkeififirkskouxaylhmuwxg2l2mwrdema=/filters/qgqka=/1"
+			}, {
+				"rel": "items",
+				"type": "searches.navigation-search-result",
+				"uri": "/searches/navigations/vestri_reference/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust=/1",
+				"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust=/1"
 			}],
 			"_child": [{
 				"self": {
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2difpu2q2mifjvg=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2difpu2q2mifjvg="
+					"uri": "/navigations/vestri_reference/kziecx2difpu2q2mifjvg=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2difpu2q2mifjvg="
 				},
 				"messages": [],
 				"links": [{
 					"rel": "parent",
 					"rev": "child",
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust="
+					"uri": "/navigations/vestri_reference/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust="
 				}, {
 					"rel": "top",
 					"type": "navigations.navigations",
-					"uri": "/navigations/vestri_b2c",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+					"uri": "/navigations/vestri_reference",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
+				}, {
+					"rel": "featuredoffers",
+					"rev": "navigation",
+					"type": "offersearches.featured-offers",
+					"uri": "/offersearches/vestri_reference/featuredoffers/kziecx2difpu2q2mifjvg=",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/featuredoffers/kziecx2difpu2q2mifjvg="
 				}, {
 					"rel": "offers",
 					"type": "offersearches.offer-search-result",
-					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvvlfaqk7inav6tkdjravgu5jobqwozjnonuxuzncgiya=/filters/qgqka=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvvlfaqk7inav6tkdjravgu5jobqwozjnonuxuzncgiya=/filters/qgqka=/1"
+					"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvvlfaqk7inav6tkdjravgu5jobqwozjnonuxuzncgiya=/filters/qgqka=/1",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvvlfaqk7inav6tkdjravgu5jobqwozjnonuxuzncgiya=/filters/qgqka=/1"
 				}, {
 					"rel": "items",
 					"type": "searches.navigation-search-result",
-					"uri": "/searches/navigations/vestri_b2c/kziecx2difpu2q2mifjvg=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2difpu2q2mifjvg=/1"
+					"uri": "/searches/navigations/vestri_reference/kziecx2difpu2q2mifjvg=/1",
+					"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kziecx2difpu2q2mifjvg=/1"
 				}],
 				"display-name": "M-Class",
 				"name": "VPA_CA_MCLASS"
 			}, {
 				"self": {
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2difpvqq2mifjvg=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2difpvqq2mifjvg="
+					"uri": "/navigations/vestri_reference/kziecx2difpvqq2mifjvg=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2difpvqq2mifjvg="
 				},
 				"messages": [],
 				"links": [{
 					"rel": "parent",
 					"rev": "child",
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust="
+					"uri": "/navigations/vestri_reference/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust="
 				}, {
 					"rel": "top",
 					"type": "navigations.navigations",
-					"uri": "/navigations/vestri_b2c",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+					"uri": "/navigations/vestri_reference",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
+				}, {
+					"rel": "featuredoffers",
+					"rev": "navigation",
+					"type": "offersearches.featured-offers",
+					"uri": "/offersearches/vestri_reference/featuredoffers/kziecx2difpvqq2mifjvg=",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/featuredoffers/kziecx2difpvqq2mifjvg="
 				}, {
 					"rel": "offers",
 					"type": "offersearches.offer-search-result",
-					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvvlfaqk7inav6wcdjravgu5jobqwozjnonuxuzncgiya=/filters/qgqka=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvvlfaqk7inav6wcdjravgu5jobqwozjnonuxuzncgiya=/filters/qgqka=/1"
+					"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvvlfaqk7inav6wcdjravgu5jobqwozjnonuxuzncgiya=/filters/qgqka=/1",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvvlfaqk7inav6wcdjravgu5jobqwozjnonuxuzncgiya=/filters/qgqka=/1"
 				}, {
 					"rel": "items",
 					"type": "searches.navigation-search-result",
-					"uri": "/searches/navigations/vestri_b2c/kziecx2difpvqq2mifjvg=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2difpvqq2mifjvg=/1"
+					"uri": "/searches/navigations/vestri_reference/kziecx2difpvqq2mifjvg=/1",
+					"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kziecx2difpvqq2mifjvg=/1"
 				}],
 				"display-name": "X-Class",
 				"name": "VPA_CA_XCLASS"
 			}, {
 				"self": {
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2uifpvinjq=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2uifpvinjq="
+					"uri": "/navigations/vestri_reference/kziecx2uifpvinjq=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2uifpvinjq="
 				},
 				"messages": [],
 				"links": [{
 					"rel": "parent",
 					"rev": "child",
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust="
+					"uri": "/navigations/vestri_reference/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2djbaver2jjzdv6qkoirpucrcbkbkekust="
 				}, {
 					"rel": "top",
 					"type": "navigations.navigations",
-					"uri": "/navigations/vestri_b2c",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+					"uri": "/navigations/vestri_reference",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
+				}, {
+					"rel": "featuredoffers",
+					"rev": "navigation",
+					"type": "offersearches.featured-offers",
+					"uri": "/offersearches/vestri_reference/featuredoffers/kziecx2uifpvinjq=",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/featuredoffers/kziecx2uifpvinjq="
 				}, {
 					"rel": "offers",
 					"type": "offersearches.offer-search-result",
-					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7krav6vbvgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7krav6vbvgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1"
+					"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7krav6vbvgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7krav6vbvgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1"
 				}, {
 					"rel": "items",
 					"type": "searches.navigation-search-result",
-					"uri": "/searches/navigations/vestri_b2c/kziecx2uifpvinjq=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2uifpvinjq=/1"
+					"uri": "/searches/navigations/vestri_reference/kziecx2uifpvinjq=/1",
+					"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kziecx2uifpvinjq=/1"
 				}],
 				"display-name": "T50",
 				"name": "VPA_TA_T50"
@@ -222,221 +272,251 @@
 		}, {
 			"self": {
 				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kzjv6q2iifjeoskoi5pvatcbjzjq=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzjv6q2iifjeoskoi5pvatcbjzjq="
+				"uri": "/navigations/vestri_reference/kzlf6vsfjbeugtcfl5hvavcjj5hfg=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kzlf6vsfjbeugtcfl5hvavcjj5hfg="
 			},
 			"messages": [],
 			"links": [{
 				"rel": "top",
 				"type": "navigations.navigations",
-				"uri": "/navigations/vestri_b2c",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				"uri": "/navigations/vestri_reference",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
+			}, {
+				"rel": "featuredoffers",
+				"rev": "navigation",
+				"type": "offersearches.featured-offers",
+				"uri": "/offersearches/vestri_reference/featuredoffers/kzlf6vsfjbeugtcfl5hvavcjj5hfg=",
+				"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/featuredoffers/kzlf6vsfjbeugtcfl5hvavcjj5hfg="
 			}, {
 				"rel": "offers",
 				"type": "offersearches.offer-search-result",
-				"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwflfgx2djbaver2jjzdv6ucmifhfhklqmftwklltnf5glirsga=/filters/qgqka=/1",
-				"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwflfgx2djbaver2jjzdv6ucmifhfhklqmftwklltnf5glirsga=/filters/qgqka=/1"
+				"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfwjlfmx2wiveesq2mivpu6ucujfhu4u5jobqwozjnonuxuzncgiya=/filters/qgqka=/1",
+				"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfwjlfmx2wiveesq2mivpu6ucujfhu4u5jobqwozjnonuxuzncgiya=/filters/qgqka=/1"
 			}, {
 				"rel": "items",
 				"type": "searches.navigation-search-result",
-				"uri": "/searches/navigations/vestri_b2c/kzjv6q2iifjeoskoi5pvatcbjzjq=/1",
-				"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kzjv6q2iifjeoskoi5pvatcbjzjq=/1"
+				"uri": "/searches/navigations/vestri_reference/kzlf6vsfjbeugtcfl5hvavcjj5hfg=/1",
+				"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kzlf6vsfjbeugtcfl5hvavcjj5hfg=/1"
 			}],
-			"display-name": "Charging Plans",
-			"name": "VS_CHARGING_PLANS"
+			"display-name": "Vehicle Options",
+			"name": "VV_VEHICLE_OPTIONS"
 		}, {
 			"self": {
 				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kzcvgvcsjfpuetk7ifbugrktknhveskfkm=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpuetk7ifbugrktknhveskfkm="
+				"uri": "/navigations/vestri_reference/kzjv6qkojzkuctc7jfhfgucfinkest2okm=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kzjv6qkojzkuctc7jfhfgucfinkest2okm="
 			},
 			"messages": [],
 			"links": [{
 				"rel": "top",
 				"type": "navigations.navigations",
-				"uri": "/navigations/vestri_b2c",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				"uri": "/navigations/vestri_reference",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
+			}, {
+				"rel": "featuredoffers",
+				"rev": "navigation",
+				"type": "offersearches.featured-offers",
+				"uri": "/offersearches/vestri_reference/featuredoffers/kzjv6qkojzkuctc7jfhfgucfinkest2okm=",
+				"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/featuredoffers/kzjv6qkojzkuctc7jfhfgucfinkest2okm="
 			}, {
 				"rel": "offers",
 				"type": "offersearches.offer-search-result",
-				"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwvleku2ukjev6qsnl5augq2fknju6usjivj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1",
-				"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwvleku2ukjev6qsnl5augq2fknju6usjivj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1"
+				"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfwvlfgx2bjzhfkqkml5eu4u2qivbviskpjzj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1",
+				"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfwvlfgx2bjzhfkqkml5eu4u2qivbviskpjzj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1"
 			}, {
 				"rel": "items",
 				"type": "searches.navigation-search-result",
-				"uri": "/searches/navigations/vestri_b2c/kzcvgvcsjfpuetk7ifbugrktknhveskfkm=/1",
-				"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kzcvgvcsjfpuetk7ifbugrktknhveskfkm=/1"
+				"uri": "/searches/navigations/vestri_reference/kzjv6qkojzkuctc7jfhfgucfinkest2okm=/1",
+				"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kzjv6qkojzkuctc7jfhfgucfinkest2okm=/1"
 			}],
-			"display-name": "Accessories",
-			"name": "VESTRI_BM_ACCESSORIES"
+			"display-name": "Annual Inspections",
+			"name": "VS_ANNUAL_INSPECTIONS"
 		}, {
 			"self": {
 				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kziecx2wiveesq2mivpucrcej5hfg=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wiveesq2mivpucrcej5hfg="
+				"uri": "/navigations/vestri_reference/kziecx2wiveesq2mivpucrcej5hfg=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2wiveesq2mivpucrcej5hfg="
 			},
 			"messages": [],
 			"links": [{
 				"rel": "top",
 				"type": "navigations.navigations",
-				"uri": "/navigations/vestri_b2c",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				"uri": "/navigations/vestri_reference",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
 			}, {
 				"rel": "child",
 				"rev": "parent",
 				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kziecx2wifpu2q2mifjvg=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wifpu2q2mifjvg="
+				"uri": "/navigations/vestri_reference/kziecx2wifpu2q2mifjvg=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2wifpu2q2mifjvg="
 			}, {
 				"rel": "child",
 				"rev": "parent",
 				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kziecx2wifpvqq2mifjvg=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wifpvqq2mifjvg="
+				"uri": "/navigations/vestri_reference/kziecx2wifpvqq2mifjvg=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2wifpvqq2mifjvg="
 			}, {
 				"rel": "child",
 				"rev": "parent",
 				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kziecx2wifpvinjq=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wifpvinjq="
+				"uri": "/navigations/vestri_reference/kziecx2wifpvinjq=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2wifpvinjq="
 			}, {
 				"rel": "child",
 				"rev": "parent",
 				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kziecx2wifpuemjq=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wifpuemjq="
+				"uri": "/navigations/vestri_reference/kziecx2wifpuemjq=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2wifpuemjq="
 			}, {
 				"rel": "offers",
 				"type": "offersearches.offer-search-result",
-				"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwjlfaqk7kzcuqskdjrcv6qkeirhu4u5jobqwozjnonuxuzncgiya=/filters/qgqka=/1",
-				"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwjlfaqk7kzcuqskdjrcv6qkeirhu4u5jobqwozjnonuxuzncgiya=/filters/qgqka=/1"
+				"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfwjlfaqk7kzcuqskdjrcv6qkeirhu4u5jobqwozjnonuxuzncgiya=/filters/qgqka=/1",
+				"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfwjlfaqk7kzcuqskdjrcv6qkeirhu4u5jobqwozjnonuxuzncgiya=/filters/qgqka=/1"
 			}, {
 				"rel": "items",
 				"type": "searches.navigation-search-result",
-				"uri": "/searches/navigations/vestri_b2c/kziecx2wiveesq2mivpucrcej5hfg=/1",
-				"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2wiveesq2mivpucrcej5hfg=/1"
+				"uri": "/searches/navigations/vestri_reference/kziecx2wiveesq2mivpucrcej5hfg=/1",
+				"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kziecx2wiveesq2mivpucrcej5hfg=/1"
 			}],
 			"_child": [{
 				"self": {
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2wifpu2q2mifjvg=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wifpu2q2mifjvg="
+					"uri": "/navigations/vestri_reference/kziecx2wifpu2q2mifjvg=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2wifpu2q2mifjvg="
 				},
 				"messages": [],
 				"links": [{
 					"rel": "parent",
 					"rev": "child",
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2wiveesq2mivpucrcej5hfg=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wiveesq2mivpucrcej5hfg="
+					"uri": "/navigations/vestri_reference/kziecx2wiveesq2mivpucrcej5hfg=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2wiveesq2mivpucrcej5hfg="
 				}, {
 					"rel": "top",
 					"type": "navigations.navigations",
-					"uri": "/navigations/vestri_b2c",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+					"uri": "/navigations/vestri_reference",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
+				}, {
+					"rel": "featuredoffers",
+					"rev": "navigation",
+					"type": "offersearches.featured-offers",
+					"uri": "/offersearches/vestri_reference/featuredoffers/kziecx2wifpu2q2mifjvg=",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/featuredoffers/kziecx2wifpu2q2mifjvg="
 				}, {
 					"rel": "offers",
 					"type": "offersearches.offer-search-result",
-					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvvlfaqk7kzav6tkdjravgu5jobqwozjnonuxuzncgiya=/filters/qgqka=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvvlfaqk7kzav6tkdjravgu5jobqwozjnonuxuzncgiya=/filters/qgqka=/1"
+					"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvvlfaqk7kzav6tkdjravgu5jobqwozjnonuxuzncgiya=/filters/qgqka=/1",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvvlfaqk7kzav6tkdjravgu5jobqwozjnonuxuzncgiya=/filters/qgqka=/1"
 				}, {
 					"rel": "items",
 					"type": "searches.navigation-search-result",
-					"uri": "/searches/navigations/vestri_b2c/kziecx2wifpu2q2mifjvg=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2wifpu2q2mifjvg=/1"
+					"uri": "/searches/navigations/vestri_reference/kziecx2wifpu2q2mifjvg=/1",
+					"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kziecx2wifpu2q2mifjvg=/1"
 				}],
 				"display-name": "M-Class",
 				"name": "VPA_VA_MCLASS"
 			}, {
 				"self": {
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2wifpvqq2mifjvg=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wifpvqq2mifjvg="
+					"uri": "/navigations/vestri_reference/kziecx2wifpvqq2mifjvg=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2wifpvqq2mifjvg="
 				},
 				"messages": [],
 				"links": [{
 					"rel": "parent",
 					"rev": "child",
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2wiveesq2mivpucrcej5hfg=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wiveesq2mivpucrcej5hfg="
+					"uri": "/navigations/vestri_reference/kziecx2wiveesq2mivpucrcej5hfg=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2wiveesq2mivpucrcej5hfg="
 				}, {
 					"rel": "top",
 					"type": "navigations.navigations",
-					"uri": "/navigations/vestri_b2c",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+					"uri": "/navigations/vestri_reference",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
+				}, {
+					"rel": "featuredoffers",
+					"rev": "navigation",
+					"type": "offersearches.featured-offers",
+					"uri": "/offersearches/vestri_reference/featuredoffers/kziecx2wifpvqq2mifjvg=",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/featuredoffers/kziecx2wifpvqq2mifjvg="
 				}, {
 					"rel": "offers",
 					"type": "offersearches.offer-search-result",
-					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvvlfaqk7kzav6wcdjravgu5jobqwozjnonuxuzncgiya=/filters/qgqka=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvvlfaqk7kzav6wcdjravgu5jobqwozjnonuxuzncgiya=/filters/qgqka=/1"
+					"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvvlfaqk7kzav6wcdjravgu5jobqwozjnonuxuzncgiya=/filters/qgqka=/1",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvvlfaqk7kzav6wcdjravgu5jobqwozjnonuxuzncgiya=/filters/qgqka=/1"
 				}, {
 					"rel": "items",
 					"type": "searches.navigation-search-result",
-					"uri": "/searches/navigations/vestri_b2c/kziecx2wifpvqq2mifjvg=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2wifpvqq2mifjvg=/1"
+					"uri": "/searches/navigations/vestri_reference/kziecx2wifpvqq2mifjvg=/1",
+					"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kziecx2wifpvqq2mifjvg=/1"
 				}],
 				"display-name": "X-Class",
 				"name": "VPA_VA_XCLASS"
 			}, {
 				"self": {
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2wifpvinjq=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wifpvinjq="
+					"uri": "/navigations/vestri_reference/kziecx2wifpvinjq=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2wifpvinjq="
 				},
 				"messages": [],
 				"links": [{
 					"rel": "parent",
 					"rev": "child",
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2wiveesq2mivpucrcej5hfg=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wiveesq2mivpucrcej5hfg="
+					"uri": "/navigations/vestri_reference/kziecx2wiveesq2mivpucrcej5hfg=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2wiveesq2mivpucrcej5hfg="
 				}, {
 					"rel": "top",
 					"type": "navigations.navigations",
-					"uri": "/navigations/vestri_b2c",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+					"uri": "/navigations/vestri_reference",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
+				}, {
+					"rel": "featuredoffers",
+					"rev": "navigation",
+					"type": "offersearches.featured-offers",
+					"uri": "/offersearches/vestri_reference/featuredoffers/kziecx2wifpvinjq=",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/featuredoffers/kziecx2wifpvinjq="
 				}, {
 					"rel": "offers",
 					"type": "offersearches.offer-search-result",
-					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7kzav6vbvgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7kzav6vbvgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1"
+					"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7kzav6vbvgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7kzav6vbvgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1"
 				}, {
 					"rel": "items",
 					"type": "searches.navigation-search-result",
-					"uri": "/searches/navigations/vestri_b2c/kziecx2wifpvinjq=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2wifpvinjq=/1"
+					"uri": "/searches/navigations/vestri_reference/kziecx2wifpvinjq=/1",
+					"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kziecx2wifpvinjq=/1"
 				}],
 				"display-name": "T50",
 				"name": "VPA_VA_T50"
 			}, {
 				"self": {
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2wifpuemjq=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wifpuemjq="
+					"uri": "/navigations/vestri_reference/kziecx2wifpuemjq=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2wifpuemjq="
 				},
 				"messages": [],
 				"links": [{
 					"rel": "parent",
 					"rev": "child",
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2wiveesq2mivpucrcej5hfg=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2wiveesq2mivpucrcej5hfg="
+					"uri": "/navigations/vestri_reference/kziecx2wiveesq2mivpucrcej5hfg=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2wiveesq2mivpucrcej5hfg="
 				}, {
 					"rel": "top",
 					"type": "navigations.navigations",
-					"uri": "/navigations/vestri_b2c",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+					"uri": "/navigations/vestri_reference",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
 				}, {
 					"rel": "offers",
 					"type": "offersearches.offer-search-result",
-					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7kzav6qrrgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7kzav6qrrgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1"
+					"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7kzav6qrrgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7kzav6qrrgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1"
 				}, {
 					"rel": "items",
 					"type": "searches.navigation-search-result",
-					"uri": "/searches/navigations/vestri_b2c/kziecx2wifpuemjq=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2wifpuemjq=/1"
+					"uri": "/searches/navigations/vestri_reference/kziecx2wifpuemjq=/1",
+					"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kziecx2wifpuemjq=/1"
 				}],
 				"display-name": "B10",
 				"name": "VPA_VA_B10"
@@ -446,364 +526,171 @@
 		}, {
 			"self": {
 				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kzcvgvcsjfpuetk7ififaqksivga=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpuetk7ififaqksivga="
+				"uri": "/navigations/vestri_reference/kzlf6vcsjfgv6ucbinfucr2fkm=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kzlf6vcsjfgv6ucbinfucr2fkm="
 			},
 			"messages": [],
 			"links": [{
 				"rel": "top",
 				"type": "navigations.navigations",
-				"uri": "/navigations/vestri_b2c",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
-			}, {
-				"rel": "child",
-				"rev": "parent",
-				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jvcu4uy=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jvcu4uy="
-			}, {
-				"rel": "child",
-				"rev": "parent",
-				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7k5hu2rkokm=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7k5hu2rkokm="
-			}, {
-				"rel": "child",
-				"rev": "parent",
-				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jneuiuy=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jneuiuy="
-			}, {
-				"rel": "child",
-				"rev": "parent",
-				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jvbuyqktkm=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jvbuyqktkm="
+				"uri": "/navigations/vestri_reference",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
 			}, {
 				"rel": "offers",
 				"type": "offersearches.offer-search-result",
-				"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwfleku2ukjev6qsnl5avaucbkjcuzklqmftwklltnf5glirsga=/filters/qgqka=/1",
-				"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwfleku2ukjev6qsnl5avaucbkjcuzklqmftwklltnf5glirsga=/filters/qgqka=/1"
+				"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfwblfmx2ukjeu2x2qifbuwqkhivj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1",
+				"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfwblfmx2ukjeu2x2qifbuwqkhivj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1"
 			}, {
 				"rel": "items",
 				"type": "searches.navigation-search-result",
-				"uri": "/searches/navigations/vestri_b2c/kzcvgvcsjfpuetk7ififaqksivga=/1",
-				"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kzcvgvcsjfpuetk7ififaqksivga=/1"
+				"uri": "/searches/navigations/vestri_reference/kzlf6vcsjfgv6ucbinfucr2fkm=/1",
+				"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kzlf6vcsjfgv6ucbinfucr2fkm=/1"
+			}],
+			"display-name": "Vehicle Trim Packages",
+			"name": "VV_TRIM_PACKAGES"
+		}, {
+			"self": {
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_reference/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy="
+			},
+			"messages": [],
+			"links": [{
+				"rel": "top",
+				"type": "navigations.navigations",
+				"uri": "/navigations/vestri_reference",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_reference/kziecx2nkbpvatcbjzhekrc7jvaustsfjzkectsdiu=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2nkbpvatcbjzhekrc7jvaustsfjzkectsdiu="
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_reference/kziecx2nkbpvinjq=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2nkbpvinjq="
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_reference/kziecx2nkbpuemjq=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2nkbpuemjq="
+			}, {
+				"rel": "offers",
+				"type": "offersearches.offer-search-result",
+				"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfxblfaqk7jvaustsuivhectsdivpvauspirkugvctvfygcz3ffvzws6tfuizda=/filters/qgqka=/1",
+				"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfxblfaqk7jvaustsuivhectsdivpvauspirkugvctvfygcz3ffvzws6tfuizda=/filters/qgqka=/1"
+			}, {
+				"rel": "items",
+				"type": "searches.navigation-search-result",
+				"uri": "/searches/navigations/vestri_reference/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy=/1",
+				"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy=/1"
 			}],
 			"_child": [{
 				"self": {
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jvcu4uy=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jvcu4uy="
+					"uri": "/navigations/vestri_reference/kziecx2nkbpvatcbjzhekrc7jvaustsfjzkectsdiu=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2nkbpvatcbjzhekrc7jvaustsfjzkectsdiu="
 				},
 				"messages": [],
 				"links": [{
 					"rel": "parent",
 					"rev": "child",
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kzcvgvcsjfpuetk7ififaqksivga=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpuetk7ififaqksivga="
+					"uri": "/navigations/vestri_reference/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy="
 				}, {
 					"rel": "top",
 					"type": "navigations.navigations",
-					"uri": "/navigations/vestri_b2c",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
-				}, {
-					"rel": "featuredoffers",
-					"rev": "navigation",
-					"type": "offersearches.featured-offers",
-					"uri": "/offersearches/vestri_b2c/featuredoffers/kzcvgvcsjfpucucqifjektc7jvcu4uy=",
-					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/featuredoffers/kzcvgvcsjfpucucqifjektc7jvcu4uy="
+					"uri": "/navigations/vestri_reference",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
 				}, {
 					"rel": "offers",
 					"type": "offersearches.offer-search-result",
-					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwnleku2ukjev6qkqkbaverkml5guktstvfygcz3ffvzws6tfuizda=/filters/qgqka=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwnleku2ukjev6qkqkbaverkml5guktstvfygcz3ffvzws6tfuizda=/filters/qgqka=/1"
+					"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfxjlfaqk7jvif6ucmifhe4rkel5gucskoivhfiqkoinc2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfxjlfaqk7jvif6ucmifhe4rkel5gucskoivhfiqkoinc2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1"
 				}, {
 					"rel": "items",
 					"type": "searches.navigation-search-result",
-					"uri": "/searches/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jvcu4uy=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jvcu4uy=/1"
-				}],
-				"display-name": "Mens",
-				"name": "VESTRI_APPAREL_MENS"
-			}, {
-				"self": {
-					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7k5hu2rkokm=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7k5hu2rkokm="
-				},
-				"messages": [],
-				"links": [{
-					"rel": "parent",
-					"rev": "child",
-					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kzcvgvcsjfpuetk7ififaqksivga=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpuetk7ififaqksivga="
-				}, {
-					"rel": "top",
-					"type": "navigations.navigations",
-					"uri": "/navigations/vestri_b2c",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
-				}, {
-					"rel": "offers",
-					"type": "offersearches.offer-search-result",
-					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwvleku2ukjev6qkqkbaverkml5lu6tkfjzj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwvleku2ukjev6qkqkbaverkml5lu6tkfjzj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1"
-				}, {
-					"rel": "items",
-					"type": "searches.navigation-search-result",
-					"uri": "/searches/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7k5hu2rkokm=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7k5hu2rkokm=/1"
-				}],
-				"display-name": "Womens",
-				"name": "VESTRI_APPAREL_WOMENS"
-			}, {
-				"self": {
-					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jneuiuy=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jneuiuy="
-				},
-				"messages": [],
-				"links": [{
-					"rel": "parent",
-					"rev": "child",
-					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kzcvgvcsjfpuetk7ififaqksivga=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpuetk7ififaqksivga="
-				}, {
-					"rel": "top",
-					"type": "navigations.navigations",
-					"uri": "/navigations/vestri_b2c",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
-				}, {
-					"rel": "offers",
-					"type": "offersearches.offer-search-result",
-					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwnleku2ukjev6qkqkbaverkml5fusrctvfygcz3ffvzws6tfuizda=/filters/qgqka=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwnleku2ukjev6qkqkbaverkml5fusrctvfygcz3ffvzws6tfuizda=/filters/qgqka=/1"
-				}, {
-					"rel": "items",
-					"type": "searches.navigation-search-result",
-					"uri": "/searches/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jneuiuy=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jneuiuy=/1"
-				}],
-				"display-name": "Kids",
-				"name": "VESTRI_APPAREL_KIDS"
-			}, {
-				"self": {
-					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jvbuyqktkm=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jvbuyqktkm="
-				},
-				"messages": [],
-				"links": [{
-					"rel": "parent",
-					"rev": "child",
-					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kzcvgvcsjfpuetk7ififaqksivga=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzcvgvcsjfpuetk7ififaqksivga="
-				}, {
-					"rel": "top",
-					"type": "navigations.navigations",
-					"uri": "/navigations/vestri_b2c",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
-				}, {
-					"rel": "offers",
-					"type": "offersearches.offer-search-result",
-					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwvleku2ukjev6qkqkbaverkml5gugtcbknj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwvleku2ukjev6qkqkbaverkml5gugtcbknj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1"
-				}, {
-					"rel": "items",
-					"type": "searches.navigation-search-result",
-					"uri": "/searches/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jvbuyqktkm=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kzcvgvcsjfpucucqifjektc7jvbuyqktkm=/1"
-				}],
-				"display-name": "M-Class",
-				"name": "VESTRI_APPAREL_MCLASS"
-			}],
-			"display-name": "Apparel",
-			"name": "VESTRI_BM_APPAREL"
-		}, {
-			"self": {
-				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kzjv6qkojzkuctc7jfhfgucfinkest2okm=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzjv6qkojzkuctc7jfhfgucfinkest2okm="
-			},
-			"messages": [],
-			"links": [{
-				"rel": "top",
-				"type": "navigations.navigations",
-				"uri": "/navigations/vestri_b2c",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
-			}, {
-				"rel": "offers",
-				"type": "offersearches.offer-search-result",
-				"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwvlfgx2bjzhfkqkml5eu4u2qivbviskpjzj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1",
-				"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwvlfgx2bjzhfkqkml5eu4u2qivbviskpjzj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1"
-			}, {
-				"rel": "items",
-				"type": "searches.navigation-search-result",
-				"uri": "/searches/navigations/vestri_b2c/kzjv6qkojzkuctc7jfhfgucfinkest2okm=/1",
-				"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kzjv6qkojzkuctc7jfhfgucfinkest2okm=/1"
-			}],
-			"display-name": "Annual Inspections",
-			"name": "VS_ANNUAL_INSPECTIONS"
-		}, {
-			"self": {
-				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kzlf6vsfjbeugtcfl5hvavcjj5hfg=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzlf6vsfjbeugtcfl5hvavcjj5hfg="
-			},
-			"messages": [],
-			"links": [{
-				"rel": "top",
-				"type": "navigations.navigations",
-				"uri": "/navigations/vestri_b2c",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
-			}, {
-				"rel": "offers",
-				"type": "offersearches.offer-search-result",
-				"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwjlfmx2wiveesq2mivpu6ucujfhu4u5jobqwozjnonuxuzncgiya=/filters/qgqka=/1",
-				"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwjlfmx2wiveesq2mivpu6ucujfhu4u5jobqwozjnonuxuzncgiya=/filters/qgqka=/1"
-			}, {
-				"rel": "items",
-				"type": "searches.navigation-search-result",
-				"uri": "/searches/navigations/vestri_b2c/kzlf6vsfjbeugtcfl5hvavcjj5hfg=/1",
-				"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kzlf6vsfjbeugtcfl5hvavcjj5hfg=/1"
-			}],
-			"display-name": "Vehicle Options",
-			"name": "VV_VEHICLE_OPTIONS"
-		}, {
-			"self": {
-				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy="
-			},
-			"messages": [],
-			"links": [{
-				"rel": "top",
-				"type": "navigations.navigations",
-				"uri": "/navigations/vestri_b2c",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
-			}, {
-				"rel": "child",
-				"rev": "parent",
-				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kziecx2nkbpvatcbjzhekrc7jvaustsfjzkectsdiu=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2nkbpvatcbjzhekrc7jvaustsfjzkectsdiu="
-			}, {
-				"rel": "child",
-				"rev": "parent",
-				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kziecx2nkbpvinjq=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2nkbpvinjq="
-			}, {
-				"rel": "child",
-				"rev": "parent",
-				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kziecx2nkbpuemjq=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2nkbpuemjq="
-			}, {
-				"rel": "offers",
-				"type": "offersearches.offer-search-result",
-				"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfxblfaqk7jvaustsuivhectsdivpvauspirkugvctvfygcz3ffvzws6tfuizda=/filters/qgqka=/1",
-				"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfxblfaqk7jvaustsuivhectsdivpvauspirkugvctvfygcz3ffvzws6tfuizda=/filters/qgqka=/1"
-			}, {
-				"rel": "items",
-				"type": "searches.navigation-search-result",
-				"uri": "/searches/navigations/vestri_b2c/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy=/1",
-				"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy=/1"
-			}],
-			"_child": [{
-				"self": {
-					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2nkbpvatcbjzhekrc7jvaustsfjzkectsdiu=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2nkbpvatcbjzhekrc7jvaustsfjzkectsdiu="
-				},
-				"messages": [],
-				"links": [{
-					"rel": "parent",
-					"rev": "child",
-					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy="
-				}, {
-					"rel": "top",
-					"type": "navigations.navigations",
-					"uri": "/navigations/vestri_b2c",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
-				}, {
-					"rel": "offers",
-					"type": "offersearches.offer-search-result",
-					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfxjlfaqk7jvif6ucmifhe4rkel5gucskoivhfiqkoinc2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfxjlfaqk7jvif6ucmifhe4rkel5gucskoivhfiqkoinc2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1"
-				}, {
-					"rel": "items",
-					"type": "searches.navigation-search-result",
-					"uri": "/searches/navigations/vestri_b2c/kziecx2nkbpvatcbjzhekrc7jvaustsfjzkectsdiu=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2nkbpvatcbjzhekrc7jvaustsfjzkectsdiu=/1"
+					"uri": "/searches/navigations/vestri_reference/kziecx2nkbpvatcbjzhekrc7jvaustsfjzkectsdiu=/1",
+					"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kziecx2nkbpvatcbjzhekrc7jvaustsfjzkectsdiu=/1"
 				}],
 				"display-name": "Planned Maintenance Kits",
 				"name": "VPA_MP_PLANNED_MAINENTANCE"
 			}, {
 				"self": {
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2nkbpvinjq=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2nkbpvinjq="
+					"uri": "/navigations/vestri_reference/kziecx2nkbpvinjq=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2nkbpvinjq="
 				},
 				"messages": [],
 				"links": [{
 					"rel": "parent",
 					"rev": "child",
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy="
+					"uri": "/navigations/vestri_reference/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy="
 				}, {
 					"rel": "top",
 					"type": "navigations.navigations",
-					"uri": "/navigations/vestri_b2c",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+					"uri": "/navigations/vestri_reference",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
+				}, {
+					"rel": "featuredoffers",
+					"rev": "navigation",
+					"type": "offersearches.featured-offers",
+					"uri": "/offersearches/vestri_reference/featuredoffers/kziecx2nkbpvinjq=",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/featuredoffers/kziecx2nkbpvinjq="
 				}, {
 					"rel": "offers",
 					"type": "offersearches.offer-search-result",
-					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7jvif6vbvgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7jvif6vbvgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1"
+					"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7jvif6vbvgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7jvif6vbvgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1"
 				}, {
 					"rel": "items",
 					"type": "searches.navigation-search-result",
-					"uri": "/searches/navigations/vestri_b2c/kziecx2nkbpvinjq=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2nkbpvinjq=/1"
+					"uri": "/searches/navigations/vestri_reference/kziecx2nkbpvinjq=/1",
+					"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kziecx2nkbpvinjq=/1"
 				}],
 				"display-name": "T50",
 				"name": "VPA_MP_T50"
 			}, {
 				"self": {
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2nkbpuemjq=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2nkbpuemjq="
+					"uri": "/navigations/vestri_reference/kziecx2nkbpuemjq=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2nkbpuemjq="
 				},
 				"messages": [],
 				"links": [{
 					"rel": "parent",
 					"rev": "child",
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy="
+					"uri": "/navigations/vestri_reference/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2nifeu4vcfjzau4q2fl5ifet2ekvbviuy="
 				}, {
 					"rel": "top",
 					"type": "navigations.navigations",
-					"uri": "/navigations/vestri_b2c",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+					"uri": "/navigations/vestri_reference",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
+				}, {
+					"rel": "featuredoffers",
+					"rev": "navigation",
+					"type": "offersearches.featured-offers",
+					"uri": "/offersearches/vestri_reference/featuredoffers/kziecx2nkbpuemjq=",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/featuredoffers/kziecx2nkbpuemjq="
 				}, {
 					"rel": "offers",
 					"type": "offersearches.offer-search-result",
-					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7jvif6qrrgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7jvif6qrrgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1"
+					"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7jvif6qrrgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvjlfaqk7jvif6qrrgcuxaylhmuwxg2l2mwrdema=/filters/qgqka=/1"
 				}, {
 					"rel": "items",
 					"type": "searches.navigation-search-result",
-					"uri": "/searches/navigations/vestri_b2c/kziecx2nkbpuemjq=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2nkbpuemjq=/1"
+					"uri": "/searches/navigations/vestri_reference/kziecx2nkbpuemjq=/1",
+					"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kziecx2nkbpuemjq=/1"
 				}],
 				"display-name": "B10",
 				"name": "VPA_MP_B10"
@@ -813,233 +700,357 @@
 		}, {
 			"self": {
 				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kzlf6vcsjfgv6ucbinfucr2fkm=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kzlf6vcsjfgv6ucbinfucr2fkm="
+				"uri": "/navigations/vestri_reference/kziecx2jjzcfku2ukjeuctc7kreverkt=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2jjzcfku2ukjeuctc7kreverkt="
 			},
 			"messages": [],
 			"links": [{
 				"rel": "top",
 				"type": "navigations.navigations",
-				"uri": "/navigations/vestri_b2c",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+				"uri": "/navigations/vestri_reference",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_reference/kziecx2jkrpuiwkoifgusq27kreveri=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2jkrpuiwkoifgusq27kreveri="
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_reference/kzav6skul5bdcma=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kzav6skul5bdcma="
 			}, {
 				"rel": "offers",
 				"type": "offersearches.offer-search-result",
-				"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwblfmx2ukjeu2x2qifbuwqkhivj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1",
-				"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfwblfmx2ukjeu2x2qifbuwqkhivj2s4dbm5ss243jpjs2emrq=/filters/qgqka=/1"
+				"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfwrlfaqk7jfheivktkrjesqkml5kesusfkouxaylhmuwxg2l2mwrdema=/filters/qgqka=/1",
+				"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfwrlfaqk7jfheivktkrjesqkml5kesusfkouxaylhmuwxg2l2mwrdema=/filters/qgqka=/1"
 			}, {
 				"rel": "items",
 				"type": "searches.navigation-search-result",
-				"uri": "/searches/navigations/vestri_b2c/kzlf6vcsjfgv6ucbinfucr2fkm=/1",
-				"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kzlf6vcsjfgv6ucbinfucr2fkm=/1"
-			}],
-			"display-name": "Vehicle Trim Packages",
-			"name": "VV_TRIM_PACKAGES"
-		}, {
-			"self": {
-				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kziecx2ujfjekuy=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ujfjekuy="
-			},
-			"messages": [],
-			"links": [{
-				"rel": "top",
-				"type": "navigations.navigations",
-				"uri": "/navigations/vestri_b2c",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
-			}, {
-				"rel": "child",
-				"rev": "parent",
-				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kziecx2ul5gugtcbknjq=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ul5gugtcbknjq="
-			}, {
-				"rel": "child",
-				"rev": "parent",
-				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kziecx2ul5megtcbknjq=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ul5megtcbknjq="
-			}, {
-				"rel": "child",
-				"rev": "parent",
-				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kziecx2ul5kdkma=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ul5kdkma="
-			}, {
-				"rel": "child",
-				"rev": "parent",
-				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kziecx2ul5gusq2iivgestq=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ul5gusq2iivgestq="
-			}, {
-				"rel": "child",
-				"rev": "parent",
-				"type": "navigations.navigation",
-				"uri": "/navigations/vestri_b2c/kziecx2ul5ke6s2pjbau2qi=",
-				"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ul5ke6s2pjbau2qi="
-			}, {
-				"rel": "offers",
-				"type": "offersearches.offer-search-result",
-				"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvflfaqk7kreverktvfygcz3ffvzws6tfuizda=/filters/qgqka=/1",
-				"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvflfaqk7kreverktvfygcz3ffvzws6tfuizda=/filters/qgqka=/1"
-			}, {
-				"rel": "items",
-				"type": "searches.navigation-search-result",
-				"uri": "/searches/navigations/vestri_b2c/kziecx2ujfjekuy=/1",
-				"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2ujfjekuy=/1"
+				"uri": "/searches/navigations/vestri_reference/kziecx2jjzcfku2ukjeuctc7kreverkt=/1",
+				"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kziecx2jjzcfku2ukjeuctc7kreverkt=/1"
 			}],
 			"_child": [{
 				"self": {
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2ul5gugtcbknjq=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ul5gugtcbknjq="
+					"uri": "/navigations/vestri_reference/kziecx2jkrpuiwkoifgusq27kreveri=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2jkrpuiwkoifgusq27kreveri="
 				},
 				"messages": [],
 				"links": [{
 					"rel": "parent",
 					"rev": "child",
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2ujfjekuy=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ujfjekuy="
+					"uri": "/navigations/vestri_reference/kziecx2jjzcfku2ukjeuctc7kreverkt=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2jjzcfku2ukjeuctc7kreverkt="
 				}, {
 					"rel": "top",
 					"type": "navigations.navigations",
-					"uri": "/navigations/vestri_b2c",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+					"uri": "/navigations/vestri_reference",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
 				}, {
 					"rel": "offers",
 					"type": "offersearches.offer-search-result",
-					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvrlfaqk7krpu2q2mifjvhklqmftwklltnf5glirsga=/filters/qgqka=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvrlfaqk7krpu2q2mifjvhklqmftwklltnf5glirsga=/filters/qgqka=/1"
+					"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfwnlfaqk7jfkf6rczjzau2skdl5kesusfvfygcz3ffvzws6tfuizda=/filters/qgqka=/1",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfwnlfaqk7jfkf6rczjzau2skdl5kesusfvfygcz3ffvzws6tfuizda=/filters/qgqka=/1"
 				}, {
 					"rel": "items",
 					"type": "searches.navigation-search-result",
-					"uri": "/searches/navigations/vestri_b2c/kziecx2ul5gugtcbknjq=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2ul5gugtcbknjq=/1"
+					"uri": "/searches/navigations/vestri_reference/kziecx2jkrpuiwkoifgusq27kreveri=/1",
+					"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kziecx2jkrpuiwkoifgusq27kreveri=/1"
+				}],
+				"display-name": "Dynamic Tire",
+				"name": "VPA_IT_DYNAMIC_TIRE"
+			}, {
+				"self": {
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_reference/kzav6skul5bdcma=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kzav6skul5bdcma="
+				},
+				"messages": [],
+				"links": [{
+					"rel": "parent",
+					"rev": "child",
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_reference/kziecx2jjzcfku2ukjeuctc7kreverkt=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2jjzcfku2ukjeuctc7kreverkt="
+				}, {
+					"rel": "top",
+					"type": "navigations.navigations",
+					"uri": "/navigations/vestri_reference",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
+				}, {
+					"rel": "offers",
+					"type": "offersearches.offer-search-result",
+					"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvflecx2jkrpuemjqvfygcz3ffvzws6tfuizda=/filters/qgqka=/1",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvflecx2jkrpuemjqvfygcz3ffvzws6tfuizda=/filters/qgqka=/1"
+				}, {
+					"rel": "items",
+					"type": "searches.navigation-search-result",
+					"uri": "/searches/navigations/vestri_reference/kzav6skul5bdcma=/1",
+					"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kzav6skul5bdcma=/1"
+				}],
+				"display-name": "B10",
+				"name": "VA_IT_B10"
+			}],
+			"display-name": "Industrial Tires",
+			"name": "VPA_INDUSTRIAL_TIRES"
+		}, {
+			"self": {
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_reference/kzlf6qkeirhu4uy=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kzlf6qkeirhu4uy="
+			},
+			"messages": [],
+			"links": [{
+				"rel": "top",
+				"type": "navigations.navigations",
+				"uri": "/navigations/vestri_reference",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
+			}, {
+				"rel": "featuredoffers",
+				"rev": "navigation",
+				"type": "offersearches.featured-offers",
+				"uri": "/offersearches/vestri_reference/featuredoffers/kzlf6qkeirhu4uy=",
+				"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/featuredoffers/kzlf6qkeirhu4uy="
+			}, {
+				"rel": "offers",
+				"type": "offersearches.offer-search-result",
+				"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvflfmx2birce6tstvfygcz3ffvzws6tfuizda=/filters/qgqka=/1",
+				"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvflfmx2birce6tstvfygcz3ffvzws6tfuizda=/filters/qgqka=/1"
+			}, {
+				"rel": "items",
+				"type": "searches.navigation-search-result",
+				"uri": "/searches/navigations/vestri_reference/kzlf6qkeirhu4uy=/1",
+				"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kzlf6qkeirhu4uy=/1"
+			}],
+			"display-name": "Commercial Vehicle Addons",
+			"name": "VV_ADDONS"
+		}, {
+			"self": {
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_reference/kziecx2ujfjekuy=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2ujfjekuy="
+			},
+			"messages": [],
+			"links": [{
+				"rel": "top",
+				"type": "navigations.navigations",
+				"uri": "/navigations/vestri_reference",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_reference/kziecx2ul5gugtcbknjq=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2ul5gugtcbknjq="
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_reference/kziecx2ul5megtcbknjq=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2ul5megtcbknjq="
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_reference/kziecx2ul5kdkma=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2ul5kdkma="
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_reference/kziecx2ul5gusq2iivgestq=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2ul5gusq2iivgestq="
+			}, {
+				"rel": "child",
+				"rev": "parent",
+				"type": "navigations.navigation",
+				"uri": "/navigations/vestri_reference/kziecx2ul5ke6s2pjbau2qi=",
+				"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2ul5ke6s2pjbau2qi="
+			}, {
+				"rel": "offers",
+				"type": "offersearches.offer-search-result",
+				"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvflfaqk7kreverktvfygcz3ffvzws6tfuizda=/filters/qgqka=/1",
+				"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvflfaqk7kreverktvfygcz3ffvzws6tfuizda=/filters/qgqka=/1"
+			}, {
+				"rel": "items",
+				"type": "searches.navigation-search-result",
+				"uri": "/searches/navigations/vestri_reference/kziecx2ujfjekuy=/1",
+				"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kziecx2ujfjekuy=/1"
+			}],
+			"_child": [{
+				"self": {
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_reference/kziecx2ul5gugtcbknjq=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2ul5gugtcbknjq="
+				},
+				"messages": [],
+				"links": [{
+					"rel": "parent",
+					"rev": "child",
+					"type": "navigations.navigation",
+					"uri": "/navigations/vestri_reference/kziecx2ujfjekuy=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2ujfjekuy="
+				}, {
+					"rel": "top",
+					"type": "navigations.navigations",
+					"uri": "/navigations/vestri_reference",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
+				}, {
+					"rel": "featuredoffers",
+					"rev": "navigation",
+					"type": "offersearches.featured-offers",
+					"uri": "/offersearches/vestri_reference/featuredoffers/kziecx2ul5gugtcbknjq=",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/featuredoffers/kziecx2ul5gugtcbknjq="
+				}, {
+					"rel": "offers",
+					"type": "offersearches.offer-search-result",
+					"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvrlfaqk7krpu2q2mifjvhklqmftwklltnf5glirsga=/filters/qgqka=/1",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvrlfaqk7krpu2q2mifjvhklqmftwklltnf5glirsga=/filters/qgqka=/1"
+				}, {
+					"rel": "items",
+					"type": "searches.navigation-search-result",
+					"uri": "/searches/navigations/vestri_reference/kziecx2ul5gugtcbknjq=/1",
+					"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kziecx2ul5gugtcbknjq=/1"
 				}],
 				"display-name": "M-Class",
 				"name": "VPA_T_MCLASS"
 			}, {
 				"self": {
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2ul5megtcbknjq=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ul5megtcbknjq="
+					"uri": "/navigations/vestri_reference/kziecx2ul5megtcbknjq=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2ul5megtcbknjq="
 				},
 				"messages": [],
 				"links": [{
 					"rel": "parent",
 					"rev": "child",
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2ujfjekuy=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ujfjekuy="
+					"uri": "/navigations/vestri_reference/kziecx2ujfjekuy=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2ujfjekuy="
 				}, {
 					"rel": "top",
 					"type": "navigations.navigations",
-					"uri": "/navigations/vestri_b2c",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+					"uri": "/navigations/vestri_reference",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
+				}, {
+					"rel": "featuredoffers",
+					"rev": "navigation",
+					"type": "offersearches.featured-offers",
+					"uri": "/offersearches/vestri_reference/featuredoffers/kziecx2ul5megtcbknjq=",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/featuredoffers/kziecx2ul5megtcbknjq="
 				}, {
 					"rel": "offers",
 					"type": "offersearches.offer-search-result",
-					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvrlfaqk7krpvqq2mifjvhklqmftwklltnf5glirsga=/filters/qgqka=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvrlfaqk7krpvqq2mifjvhklqmftwklltnf5glirsga=/filters/qgqka=/1"
+					"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvrlfaqk7krpvqq2mifjvhklqmftwklltnf5glirsga=/filters/qgqka=/1",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvrlfaqk7krpvqq2mifjvhklqmftwklltnf5glirsga=/filters/qgqka=/1"
 				}, {
 					"rel": "items",
 					"type": "searches.navigation-search-result",
-					"uri": "/searches/navigations/vestri_b2c/kziecx2ul5megtcbknjq=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2ul5megtcbknjq=/1"
+					"uri": "/searches/navigations/vestri_reference/kziecx2ul5megtcbknjq=/1",
+					"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kziecx2ul5megtcbknjq=/1"
 				}],
 				"display-name": "X-Class",
 				"name": "VPA_T_XCLASS"
 			}, {
 				"self": {
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2ul5kdkma=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ul5kdkma="
+					"uri": "/navigations/vestri_reference/kziecx2ul5kdkma=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2ul5kdkma="
 				},
 				"messages": [],
 				"links": [{
 					"rel": "parent",
 					"rev": "child",
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2ujfjekuy=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ujfjekuy="
+					"uri": "/navigations/vestri_reference/kziecx2ujfjekuy=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2ujfjekuy="
 				}, {
 					"rel": "top",
 					"type": "navigations.navigations",
-					"uri": "/navigations/vestri_b2c",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+					"uri": "/navigations/vestri_reference",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
+				}, {
+					"rel": "featuredoffers",
+					"rev": "navigation",
+					"type": "offersearches.featured-offers",
+					"uri": "/offersearches/vestri_reference/featuredoffers/kziecx2ul5kdkma=",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/featuredoffers/kziecx2ul5kdkma="
 				}, {
 					"rel": "offers",
 					"type": "offersearches.offer-search-result",
-					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvflfaqk7krpvinjqvfygcz3ffvzws6tfuizda=/filters/qgqka=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvflfaqk7krpvinjqvfygcz3ffvzws6tfuizda=/filters/qgqka=/1"
+					"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvflfaqk7krpvinjqvfygcz3ffvzws6tfuizda=/filters/qgqka=/1",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvflfaqk7krpvinjqvfygcz3ffvzws6tfuizda=/filters/qgqka=/1"
 				}, {
 					"rel": "items",
 					"type": "searches.navigation-search-result",
-					"uri": "/searches/navigations/vestri_b2c/kziecx2ul5kdkma=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2ul5kdkma=/1"
+					"uri": "/searches/navigations/vestri_reference/kziecx2ul5kdkma=/1",
+					"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kziecx2ul5kdkma=/1"
 				}],
 				"display-name": "T50",
 				"name": "VPA_T_T50"
 			}, {
 				"self": {
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2ul5gusq2iivgestq=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ul5gusq2iivgestq="
+					"uri": "/navigations/vestri_reference/kziecx2ul5gusq2iivgestq=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2ul5gusq2iivgestq="
 				},
 				"messages": [],
 				"links": [{
 					"rel": "parent",
 					"rev": "child",
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2ujfjekuy=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ujfjekuy="
+					"uri": "/navigations/vestri_reference/kziecx2ujfjekuy=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2ujfjekuy="
 				}, {
 					"rel": "top",
 					"type": "navigations.navigations",
-					"uri": "/navigations/vestri_b2c",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+					"uri": "/navigations/vestri_reference",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
 				}, {
 					"rel": "offers",
 					"type": "offersearches.offer-search-result",
-					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvzlfaqk7krpu2skdjbcuyskovfygcz3ffvzws6tfuizda=/filters/qgqka=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvzlfaqk7krpu2skdjbcuyskovfygcz3ffvzws6tfuizda=/filters/qgqka=/1"
+					"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvzlfaqk7krpu2skdjbcuyskovfygcz3ffvzws6tfuizda=/filters/qgqka=/1",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvzlfaqk7krpu2skdjbcuyskovfygcz3ffvzws6tfuizda=/filters/qgqka=/1"
 				}, {
 					"rel": "items",
 					"type": "searches.navigation-search-result",
-					"uri": "/searches/navigations/vestri_b2c/kziecx2ul5gusq2iivgestq=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2ul5gusq2iivgestq=/1"
+					"uri": "/searches/navigations/vestri_reference/kziecx2ul5gusq2iivgestq=/1",
+					"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kziecx2ul5gusq2iivgestq=/1"
 				}],
 				"display-name": "Michelin",
 				"name": "VPA_T_MICHELIN"
 			}, {
 				"self": {
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2ul5ke6s2pjbau2qi=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ul5ke6s2pjbau2qi="
+					"uri": "/navigations/vestri_reference/kziecx2ul5ke6s2pjbau2qi=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2ul5ke6s2pjbau2qi="
 				},
 				"messages": [],
 				"links": [{
 					"rel": "parent",
 					"rev": "child",
 					"type": "navigations.navigation",
-					"uri": "/navigations/vestri_b2c/kziecx2ujfjekuy=",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c/kziecx2ujfjekuy="
+					"uri": "/navigations/vestri_reference/kziecx2ujfjekuy=",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference/kziecx2ujfjekuy="
 				}, {
 					"rel": "top",
 					"type": "navigations.navigations",
-					"uri": "/navigations/vestri_b2c",
-					"href": "https://vestri-us.epdemos.com/cortex/navigations/vestri_b2c"
+					"uri": "/navigations/vestri_reference",
+					"href": "http://reference.epdemos.com/cortex/navigations/vestri_reference"
 				}, {
 					"rel": "offers",
 					"type": "offersearches.offer-search-result",
-					"uri": "/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvzlfaqk7krpvit2lj5eectkbvfygcz3ffvzws6tfuizda=/filters/qgqka=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/offersearches/vestri_b2c/offers/qkwwgylumvtw64tzfvrw6zdfvzlfaqk7krpvit2lj5eectkbvfygcz3ffvzws6tfuizda=/filters/qgqka=/1"
+					"uri": "/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvzlfaqk7krpvit2lj5eectkbvfygcz3ffvzws6tfuizda=/filters/qgqka=/1",
+					"href": "http://reference.epdemos.com/cortex/offersearches/vestri_reference/offers/qkwwgylumvtw64tzfvrw6zdfvzlfaqk7krpvit2lj5eectkbvfygcz3ffvzws6tfuizda=/filters/qgqka=/1"
 				}, {
 					"rel": "items",
 					"type": "searches.navigation-search-result",
-					"uri": "/searches/navigations/vestri_b2c/kziecx2ul5ke6s2pjbau2qi=/1",
-					"href": "https://vestri-us.epdemos.com/cortex/searches/navigations/vestri_b2c/kziecx2ul5ke6s2pjbau2qi=/1"
+					"uri": "/searches/navigations/vestri_reference/kziecx2ul5ke6s2pjbau2qi=/1",
+					"href": "http://reference.epdemos.com/cortex/searches/navigations/vestri_reference/kziecx2ul5ke6s2pjbau2qi=/1"
 				}],
 				"display-name": "Yokohama",
 				"name": "VPA_T_TOKOHAMA"


### PR DESCRIPTION
Description:
<!--A brief description of changes. Things to include: WIP? Dependent PR's opened against other tickets? -->

this PR is a hotfix for `appheadernavigation` component.  Adjusts the mock data to use the reference.elasticpath.com instance instead of vestri-us.epdemos.com instance.

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Component Updates:
<!--Have you updated components/package.json and components/package-lock.json for any components that have been updated? -->
- [ ] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests

1. Just ensure that the component shows up in storybook
2. notice that the mock data has reference.elasticpath.com href attributes values.

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
