### PR TITLE
Fixed account link for Buyer Admins with other roles

### DIFF
--- a/components/package-lock.json
+++ b/components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/store-components",
-  "version": "1.1.37",
+  "version": "1.1.38",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/store-components",
-  "version": "1.1.37",
+  "version": "1.1.38",
   "main": "build/cjs/index",
   "main:src": "src/index",
   "types": "src/index",

--- a/components/src/AppHeaderLogin/appheaderlogin.main.tsx
+++ b/components/src/AppHeaderLogin/appheaderlogin.main.tsx
@@ -126,6 +126,7 @@ class AppHeaderLoginMain extends React.Component<AppHeaderLoginMainProps, AppHea
     }
 
     handleModalClose() {
+      this.getAccountData();
       this.setState({
         openModal: false,
         openCartModal: false,


### PR DESCRIPTION
Description:
Currently, in the B2B enabled storefront, if a `Buyer Admin` logs in, and they have any other roles assigned, they are unable to access the Accounts link in the appheaderlogin drop down because their account data is not being populated.  I have fixed it so that after a selection is made in the Shop For dialog, the accounts data is checked once again to see if they have `Buyer Admin` privileges. 

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Component Updates:
<!--Have you updated components/package.json and components/package-lock.json for any components that have been updated? -->
- [x] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests
1. Logged in as a `Buyer Admin`.  Still able to view accounts page
2. Logged in as a `Buyer`.  Unable to view the accounts page
3. Logged in as a `Buyer Admin` who is also a `Buyer`.  Now able to view accounts page.

If you need access to a 7.6 instance with AM for testing, ping me for details.

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
