### PR TITLE
fix b2bSideMenu

### DIFF
--- a/components/src/B2bSideMenu/b2b.sidemenu.stories.tsx
+++ b/components/src/B2bSideMenu/b2b.sidemenu.stories.tsx
@@ -21,7 +21,7 @@
 import React from 'react';
 import Readme from './README.md';
 import { storiesOf } from '@storybook/react';
-import { Router } from 'react-router';
+import { MemoryRouter } from 'react-router';
 import { action } from '@storybook/addon-actions';
 import createMemoryHistory from 'history/createMemoryHistory';
 import B2bSideMenu from './b2b.sidemenu';
@@ -47,5 +47,11 @@ storiesOf('Components|B2bSideMenu', module)
       sidebar: Readme,
     },
   })
-  .addDecorator(story => <Router history={history}>{story()}</Router>)
-  .add('B2bSideMenu', () => <B2bSideMenu sideMenuItems={object('sideMenuItems',sideMenuItems)} />);
+  .addDecorator(story =>  <MemoryRouter 
+                            initialEntries={[{ pathname: "/b2b" }]}
+                            initialIndex={1}>
+                              {story()}
+                          </MemoryRouter>)
+  .add('B2bSideMenu', () => {
+    return (<B2bSideMenu sideMenuItems={object('sideMenuItems', sideMenuItems)} />);
+  });

--- a/components/src/B2bSideMenu/b2b.sidemenu.tsx
+++ b/components/src/B2bSideMenu/b2b.sidemenu.tsx
@@ -20,18 +20,19 @@
  */
 
 import React from 'react';
-import { Route, Link } from 'react-router-dom';
+import { withRouter, Route, Link } from 'react-router-dom';
 import intl from 'react-intl-universal';
 import './b2b.sidemenu.less';
 
 interface B2bSideMenuProps {
     sideMenuItems: any,
+    location: any,
 }
 interface B2bSideMenuState {
     isOpen: boolean,
 }
 
-export default class B2bSideMenu extends React.Component<B2bSideMenuProps, B2bSideMenuState> {
+class B2bSideMenu extends React.Component<B2bSideMenuProps, B2bSideMenuState> {
   constructor(props) {
     super(props);
 
@@ -56,9 +57,10 @@ export default class B2bSideMenu extends React.Component<B2bSideMenuProps, B2bSi
   }
 
   render() {
-    const { sideMenuItems } = this.props;
+    const { sideMenuItems, location } = this.props;
     const { isOpen } = this.state;
-    const currentSideMenuItems = sideMenuItems.filter(el => el.to === window.location.pathname);
+    const currentSideMenuItems = sideMenuItems.filter(el => el.to === location.pathname);
+
     return (
       <div className="side-menu-component">
         <button
@@ -75,7 +77,7 @@ export default class B2bSideMenu extends React.Component<B2bSideMenuProps, B2bSi
                 path={elem.to}
                 exact
               >
-                <Link className={`menu-item ${window.location.pathname === elem.to ? 'selected' : ''}`} to={elem.to}>
+                <Link className={`menu-item ${location.pathname === elem.to ? 'selected' : ''}`} to={elem.to}>
                   {intl.get(elem.children)}
                 </Link>
               </Route>
@@ -86,3 +88,5 @@ export default class B2bSideMenu extends React.Component<B2bSideMenuProps, B2bSi
     );
   }
 }
+
+export default withRouter(B2bSideMenu);


### PR DESCRIPTION
Description:

Fixes issue #495 

Able to get the sidemenu component to show up in storybook.

Change logic in the sidemenu to use the passed down react-router location properties instead of the browser location properties.


Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Component Updates:
<!--Have you updated components/package.json and components/package-lock.json for any components that have been updated? -->
- [x] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests

1.) Check that the sidemenu shows up in storybook
2.) Check that the sidemenu still shows up in the reference store application

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
