### PR TITLE
fix message container in storybook and get rid of obsolete lifecycle …

### DIFF
--- a/components/src/MessageContainer/messagecontainer.stories.tsx
+++ b/components/src/MessageContainer/messagecontainer.stories.tsx
@@ -25,7 +25,7 @@ import { storiesOf } from '@storybook/react';
 
 import { MemoryRouter } from 'react-router';
 import MessageContainer from './messagecontainer';
-import { boolean, object, text } from '@storybook/addon-knobs';
+import { object } from '@storybook/addon-knobs';
 const errorMessage = {
   debugMessages: 'Customer email address must be specified.',
   type: 'error',
@@ -53,6 +53,6 @@ storiesOf('Components|MessageContainer', module)
   .addDecorator(story => (
     <MemoryRouter initialEntries={['/']}>{story()}</MemoryRouter>
   ))
-  .add('MessageContainer Error Message', () => <MessageContainer message={object('message', errorMessage)} />)
-  .add('ProductDisplayItemMain Warning Message', () => <MessageContainer message={object('message', warningMessage)} />)
-  .add('ProductDisplayItemMain Dark Message', () => <MessageContainer message={object('message', darkMessage)} />);
+  .add('MessageContainer Error Message', () => <MessageContainer message={object('errorMessage', [errorMessage])} />)
+  .add('ProductDisplayItemMain Warning Message', () => <MessageContainer message={object('message', [warningMessage])} />)
+  .add('ProductDisplayItemMain Dark Message', () => <MessageContainer message={object('message', [darkMessage])} />);

--- a/components/src/MessageContainer/messagecontainer.stories.tsx
+++ b/components/src/MessageContainer/messagecontainer.stories.tsx
@@ -53,6 +53,6 @@ storiesOf('Components|MessageContainer', module)
   .addDecorator(story => (
     <MemoryRouter initialEntries={['/']}>{story()}</MemoryRouter>
   ))
-  .add('MessageContainer Error Message', () => <MessageContainer message={object('errorMessage', [errorMessage])} />)
+  .add('MessageContainer Error Message', () => <MessageContainer message={object('message', [errorMessage])} />)
   .add('ProductDisplayItemMain Warning Message', () => <MessageContainer message={object('message', [warningMessage])} />)
   .add('ProductDisplayItemMain Dark Message', () => <MessageContainer message={object('message', [darkMessage])} />);

--- a/components/src/MessageContainer/messagecontainer.tsx
+++ b/components/src/MessageContainer/messagecontainer.tsx
@@ -45,8 +45,11 @@ class MessageContainer extends React.Component<MessageContainerProps, MessageCon
     this.handleCloseMessageContainer = this.handleCloseMessageContainer.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.setState({ messages: nextProps.message });
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (nextProps.message !== prevState.messages) {
+      return { messages: nextProps.message };
+    }
+    return null;
   }
 
   handleCloseMessageContainer(index) {


### PR DESCRIPTION
…function

Description:
<!--A brief description of changes. Things to include: WIP? Dependent PR's opened against other tickets? -->

#501 

Fixes the messaging component to show up in storybook and updates it to use non-deprecated `getDerivedStateFromProps` lifecycle method instead of `componentWillReceiveProps`

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [ ] No linting errors

Component Updates:
<!--Have you updated components/package.json and components/package-lock.json for any components that have been updated? -->
- [x] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests

Check that the messaging container now shows up in storybook and can be toggled by knobs.

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
