### PR TITLE
Feature/remove component will receive props from pages

### DIFF
--- a/app/src/containers/CartPage.tsx
+++ b/app/src/containers/CartPage.tsx
@@ -126,10 +126,6 @@ class CartPage extends React.Component<RouteComponentProps, CartPageState> {
     this.fetchCartData();
   }
 
-  componentWillReceiveProps() {
-    this.fetchCartData();
-  }
-
   fetchCartData() {
     const { selectedCartNumber } = this.state;
     login().then(() => {

--- a/app/src/containers/CheckoutPage.tsx
+++ b/app/src/containers/CheckoutPage.tsx
@@ -115,10 +115,6 @@ class CheckoutPage extends React.Component<CheckoutPageProps, CheckoutPageState>
     this.fetchGiftCardsData();
   }
 
-  componentWillReceiveProps() {
-    this.fetchProfileData();
-  }
-
   fetchProfileData() {
     login().then(() => {
       cortexFetch(`/?zoom=${zoomArrayProfile.join()}`,

--- a/app/src/containers/ProfilePage.tsx
+++ b/app/src/containers/ProfilePage.tsx
@@ -86,10 +86,6 @@ class ProfilePage extends React.Component<RouteComponentProps, ProfilePageState>
     this.fetchProfileData();
   }
 
-  componentWillReceiveProps() {
-    this.fetchProfileData();
-  }
-
   fetchProfileData() {
     login().then(() => {
       const options = {

--- a/app/src/containers/WishListsPage.tsx
+++ b/app/src/containers/WishListsPage.tsx
@@ -72,10 +72,6 @@ class WishListsPage extends React.Component<RouteComponentProps, WishListsPageSt
     this.fetchwishListData();
   }
 
-  componentWillReceiveProps() {
-    this.fetchwishListData();
-  }
-
   handleQuantityChange() {
     this.setState({ isLoading: true });
     this.fetchwishListData();


### PR DESCRIPTION
Description:
<!--A brief description of changes. Things to include: WIP? Dependent PR's opened against other tickets? -->

Remove deprecated function `componentWillReceiveProps` from pages that wont ever be receiving new properties anyways as they are the top level component

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Component Updates:
<!--Have you updated components/package.json and components/package-lock.json for any components that have been updated? -->
- [ ] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests

Tests that the pages still update normally.

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
