### PR TITLE
Fix for CSV uploader for Windows

### DIFF
--- a/app/src/containers/b2b/B2BMain.tsx
+++ b/app/src/containers/b2b/B2BMain.tsx
@@ -130,7 +130,7 @@ export default class B2BMain extends React.Component<B2BMainProps, B2BMainState>
   async uploadSelectedFile(): Promise<any> {
     const formData = new FormData();
     const fileInput = this.fileInputRef.current;
-    formData.append('associates', fileInput.files[0]);
+    formData.append('associates', new Blob([fileInput.files[0]], { type: 'text/csv' }));
 
     const options = {
       method: 'POST',


### PR DESCRIPTION
Description:
<!--A brief description of changes. Things to include: WIP? Dependent PR's opened against other tickets? -->
- Wrap file in blob and force content type as text/csv. This is expected to be set by the browser, but the API will only accept text/csv and such other browsers will not set this content-type.

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Component Updates:
<!--Have you updated components/package.json and components/package-lock.json for any components that have been updated? -->
- [ ] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [x] E2E tests (npm test run with `e2e`)
- [x] Manual tests

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
