### PR TITLE
Fix/fix component build

### DIFF
--- a/components/tsconfig.json
+++ b/components/tsconfig.json
@@ -21,7 +21,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "noEmit": false,
-    "outDir": "build",
+    "outDir": "build/types",
     "esModuleInterop":true,
     "declarationMap": true
   },

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
     "typescript": "^3.6.3"
   },
   "scripts": {
-    "start": "yarn build-components && cd app && yarn start",
+    "start": "yarn build-component-types && cd app && yarn start",
     "build": "yarn build-components && cd app && yarn build",
+    "build-component-types": "cd components && tsc --EmitDeclarationOnly",
     "build-components" : "cd components && yarn build",
     "test": " cd app && yarn test",
     "storybook": " cd storybook && yarn storybook",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "react-simple-chatbot": "^0.6.1",
     "styled-components": "^4.3.2"
   },
+  "devDependencies": {
+    "typescript": "^3.6.3"
+  },
   "scripts": {
     "start": "yarn build-components && cd app && yarn start",
     "build": "yarn build-components && cd app && yarn build",


### PR DESCRIPTION
Description:
<!--A brief description of changes. Things to include: WIP? Dependent PR's opened against other tickets? -->

https://jira.elasticpath.com/browse/RS-636

This PR aims to decrease our main `app` ref store start up time.  

In lieu of changes made to our `types` path to enable our published `build` bundle to be consumed properly we ran into the issue of not being to consume our components without building our entire `build` folder with a `webpack` command.  This PR maintains the changes made to our `types` path and a dependency to the `types` within the `build` folder, but instead of building the entire bundle with our `yarn start` command we only bulid the necessary types to run our main ref store application.

We use the `tsc` command from the `typescript` dependency.  It has been added to the root of the project as devDependency.

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Component Updates:
<!--Have you updated components/package.json and components/package-lock.json for any components that have been updated? -->
- [x] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests

1.) Able to run `yarn start` from root and have application start up with no errors even with the `build` folder deleted before hand.

NOTE: unfamiliar with the prod deployment process.  That still needs to be tested.  Wouldn't mind seeing how thats done :).

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [x] Requires documentation updates
