### PR TITLE
update customer profile email attribute in vestri

### DIFF
--- a/data/ep-blueprint-data/importexport/customerprofile_attributes.xml
+++ b/data/ep-blueprint-data/importexport/customerprofile_attributes.xml
@@ -61,7 +61,7 @@
     <usage>CustomerProfile</usage>
     <type>ShortText</type>
     <multilanguage>false</multilanguage>
-    <required>true</required>
+    <required>false</required>
     <multivalue>false</multivalue>
     <global>false</global>
 </attribute>


### PR DESCRIPTION
Description:
as of ep-commerce 7.5.0 customer profile email **CP_EMAIL** is optional, this change updates this setting so that cucumber tests don't fail when used with this data set

Linting:

- [ ] No linting errors

Component Updates:

- [ ] Component package requires update on npm @elasticpath/store-components

Tests:

- [ ] E2E tests (npm test run with e2e)
- [ ] Manual tests

Documentation:

- [ ] Requires documentation updates