### PR TITLE
Feature/po widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ _site
 build
 dist
 
+
+.vscode
+
 # misc
 .DS_Store
 .env.local

--- a/app/src/containers/CheckoutPage.tsx
+++ b/app/src/containers/CheckoutPage.tsx
@@ -24,7 +24,7 @@ import intl from 'react-intl-universal';
 import { RouteComponentProps } from 'react-router-dom';
 import Modal from 'react-responsive-modal';
 import {
-  GiftcertificateFormMain, AddressContainer, CheckoutSummaryList, ShippingOptionContainer, PaymentMethodContainer, ProfileemailinfoMain, PaymentFormMain, AddressFormMain,
+  GiftcertificateFormMain, AddressContainer, CheckoutSummaryList, ShippingOptionContainer, PaymentMethodContainer, ProfileemailinfoMain, PaymentFormMain, AddressFormMain, PurchaseOrderWidget,
 } from '@elasticpath/store-components';
 import { login } from '../utils/AuthService';
 import { cortexFetch } from '../utils/Cortex';
@@ -583,6 +583,7 @@ class CheckoutPage extends React.Component<CheckoutPageProps, CheckoutPageState>
         <h2>
           {intl.get('payment-method')}
         </h2>
+        <PurchaseOrderWidget timeoutBeforeVerify={3000} />
         <div data-region="paymentMethodSelectorsRegion" className="checkout-region-inner-container">
           {this.renderPayments()}
         </div>

--- a/app/src/containers/CheckoutPage.tsx
+++ b/app/src/containers/CheckoutPage.tsx
@@ -24,7 +24,7 @@ import intl from 'react-intl-universal';
 import { RouteComponentProps } from 'react-router-dom';
 import Modal from 'react-responsive-modal';
 import {
-  GiftcertificateFormMain, AddressContainer, CheckoutSummaryList, ShippingOptionContainer, PaymentMethodContainer, ProfileemailinfoMain, PaymentFormMain, AddressFormMain, PurchaseOrderWidget,
+  GiftcertificateFormMain, AddressContainer, CheckoutSummaryList, ShippingOptionContainer, PaymentMethodContainer, ProfileemailinfoMain, PaymentFormMain, AddressFormMain,
 } from '@elasticpath/store-components';
 import { login } from '../utils/AuthService';
 import { cortexFetch } from '../utils/Cortex';
@@ -583,7 +583,6 @@ class CheckoutPage extends React.Component<CheckoutPageProps, CheckoutPageState>
         <h2>
           {intl.get('payment-method')}
         </h2>
-        <PurchaseOrderWidget timeoutBeforeVerify={3000} />
         <div data-region="paymentMethodSelectorsRegion" className="checkout-region-inner-container">
           {this.renderPayments()}
         </div>

--- a/app/src/containers/ProfilePage.tsx
+++ b/app/src/containers/ProfilePage.tsx
@@ -183,7 +183,7 @@ class ProfilePage extends React.Component<RouteComponentProps, ProfilePageState>
 
   render() {
     const { profileData, showResetPasswordButton, dataPolicyData } = this.state;
-    
+
     return (
       <div>
         <div className="container profile-container">

--- a/app/src/localization/en-CA.json
+++ b/app/src/localization/en-CA.json
@@ -356,5 +356,9 @@
   "remove-associate": "Remove Associate",
   "confirm-delete-associate": "Are you sure you would like to remove this associate?",
   "no": "No",
-  "yes": "Yes"
+  "yes": "Yes",
+  "view": "View",
+  "pay-with-po": "Pay With PO",
+  "purchase-order": "Purchase Order",
+  "invalid-po-number": "Invalid PO number"
 }

--- a/app/src/localization/fr-FR.json
+++ b/app/src/localization/fr-FR.json
@@ -356,5 +356,9 @@
   "remove-associate": "R-e-m-o-v-e- -A-s-s-o-c-i-a-t-e",
   "confirm-delete-associate": "A-r-e- -y-o-u- -s-u-r-e- -y-o-u- -w-o-u-l-d- -l-i-k-e- -t-o- -r-e-m-o-v-e- -t-h-i-s- -a-s-s-o-c-i-a-t-e-?",
   "no": "N-o",
-  "yes": "Y-e-s"
+  "yes": "Y-e-s",
+  "view": "V-i-e-w",
+  "pay-with-po": "P-a-y W-i-t-h P-O",
+  "purchase-order": "P-u-r-c-h-a-s-e O-r-d-e-r",
+  "invalid-po-number": "I-n-v-a-l-i-d P-O n-u-m-b-e-r"
 }

--- a/components/src/PurchaseOrderWidget/README.md
+++ b/components/src/PurchaseOrderWidget/README.md
@@ -8,6 +8,10 @@ The parameter `timeoutBeforeVerify` controls how long after the user stops typin
 
 At the moment the component does not check validity of the PO number against cortex or any third party service.  It has been programmed to simluate validating numbers `1234`, `2345`, `3456`.  When placed into a real implementation parts of this code should be taken out.  Comments in the code will guide how to do that.
 
+onPayWithPO is a callback invoked once the `Pay With PO` button is pressed.
+
+onViewClicked is a callback invoked once the `View` button in the top right is clicked after PO number validation.
+
 
 #### Usage
 
@@ -18,7 +22,7 @@ import { PurchaseOrderWidget } from '@elasticpath/store-components';
 #### Example
 
 ```js
-<PurchaseOrderWidget />
+<PurchaseOrderWidget timeoutBeforeVerify={1000} onPayWithPO={() => {}} onViewClicked={() => {}} />
 ```
 
 #### Properties

--- a/components/src/PurchaseOrderWidget/README.md
+++ b/components/src/PurchaseOrderWidget/README.md
@@ -4,6 +4,8 @@
 
 A purchase order widget that allows entry, validation, and a link to view the purchase order in more detail.
 
+At the moment the component does not check validity of the PO number against cortex or any third party service.  It has been programmed to simluate validating numbers `1234`, `2345`, `3456`.  When placed into a real implementation parts of this code should be taken out.  Comments in the code will guide how to do that.
+
 #### Usage
 
 ```js

--- a/components/src/PurchaseOrderWidget/README.md
+++ b/components/src/PurchaseOrderWidget/README.md
@@ -1,0 +1,21 @@
+# AddPromotionContainer
+
+#### Description
+
+A purchase order widget that allows entry, validation, and a link to view the purchase order in more detail.
+
+#### Usage
+
+```js
+import { PurchaseOrderWidget } from '@elasticpath/store-components';
+```
+
+#### Example
+
+```js
+<PurchaseOrderWidget />
+```
+
+#### Properties
+
+<!-- PROPS -->

--- a/components/src/PurchaseOrderWidget/README.md
+++ b/components/src/PurchaseOrderWidget/README.md
@@ -4,7 +4,10 @@
 
 A purchase order widget that allows entry, validation, and a link to view the purchase order in more detail.
 
+The parameter `timeoutBeforeVerify` controls how long after the user stops typing to invoke the PO number validation request.
+
 At the moment the component does not check validity of the PO number against cortex or any third party service.  It has been programmed to simluate validating numbers `1234`, `2345`, `3456`.  When placed into a real implementation parts of this code should be taken out.  Comments in the code will guide how to do that.
+
 
 #### Usage
 

--- a/components/src/PurchaseOrderWidget/README.md
+++ b/components/src/PurchaseOrderWidget/README.md
@@ -1,4 +1,4 @@
-# AddPromotionContainer
+# PurchaseOrderWidget
 
 #### Description
 

--- a/components/src/PurchaseOrderWidget/README.md
+++ b/components/src/PurchaseOrderWidget/README.md
@@ -2,7 +2,7 @@
 
 #### Description
 
-A purchase order widget that allows entry, validation, and a link to view the purchase order in more detail.
+A purchase order widget that allows entry, validation, and a link to view the purchase order in more detail once verification succeeds.
 
 The parameter `timeoutBeforeVerify` controls how long after the user stops typing to invoke the PO number validation request.
 

--- a/components/src/PurchaseOrderWidget/purchase.order.widget.less
+++ b/components/src/PurchaseOrderWidget/purchase.order.widget.less
@@ -25,9 +25,20 @@
   border: 1px solid @mainBorderColor;
   padding: 20px;
   
-  .view-button-inactive{
+  .view-button {
     border: none;
+  }
+
+  .inactive {
     color: @firstComplimentTextColor;
+  }
+
+  .active {
+    color: @buttonActiveColor;
+
+    &:hover {
+      color: @buttonFocusColor;
+    }
   }
   
   .purchase-order-widget-top {
@@ -102,4 +113,6 @@
   .close-btn {
     display: none
   }
+
+  
 }

--- a/components/src/PurchaseOrderWidget/purchase.order.widget.less
+++ b/components/src/PurchaseOrderWidget/purchase.order.widget.less
@@ -1,0 +1,56 @@
+/**
+ * Copyright © 2019 Elastic Path Software Inc. All rights reserved.
+ *
+ * This is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this license. If not, see
+ *
+ *     https://www.gnu.org/licenses/
+ *
+ *
+ */
+
+ @import './../../../app/src/theme/common.less';
+
+.purchase-order-widget-container {
+  border: 1px solid @mainBorderColor;
+  padding: 20px;
+  
+  .view-button-inactive{
+    border: none;
+    color: @firstComplimentTextColor;
+  }
+  
+  .purchase-order-widget-top {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+  
+  .pay-with-po-btn {
+    margin-top: 30px;
+  }
+
+  .form-control {
+    display: block;
+    height: 34px;
+    padding: 6px 12px;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    font-size: 14px;
+    color: #555555;
+    background-color: @mainBackgroundColor;
+    border: 1px solid #cccccc;
+    border-radius: 4px;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  }
+}

--- a/components/src/PurchaseOrderWidget/purchase.order.widget.less
+++ b/components/src/PurchaseOrderWidget/purchase.order.widget.less
@@ -53,4 +53,16 @@
     border-radius: 4px;
     box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   }
+
+  .purchase-order-widget-input-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
+  .miniLoader-container {
+    position: absolute;
+    margin-top:2px;
+    right: 30px;
+  }
 }

--- a/components/src/PurchaseOrderWidget/purchase.order.widget.less
+++ b/components/src/PurchaseOrderWidget/purchase.order.widget.less
@@ -60,7 +60,7 @@
     justify-content: space-between;
   }
 
-  .miniLoader-container {
+  .inputLoader-container {
     position: absolute;
     margin-top:2px;
     right: 30px;
@@ -78,7 +78,6 @@
         content: "";
         position: absolute;
         top: 10px;
-        left: -1px;
         width: 12px;
         height: 7px;
         border: solid 2px #6dd401;
@@ -87,5 +86,20 @@
         transform: translate(2px, 1px) rotate(-45deg);
       }
     }
+  }
+
+  .inputLoader {
+    border: 3px solid @firstComplimentBackground;
+    border-top: 3px solid @secondComplimentColor;
+    width: 20px;
+    height: 20px !important;
+    border-radius: 80%;
+    animation: spin 0.5s linear infinite;
+    margin: 0 auto;
+    margin-top: 15px;
+  }
+
+  .close-btn {
+    display: none
   }
 }

--- a/components/src/PurchaseOrderWidget/purchase.order.widget.less
+++ b/components/src/PurchaseOrderWidget/purchase.order.widget.less
@@ -71,9 +71,9 @@
     margin-top: 10px;
     width: 18px;
     height: 18px;
+    background-color: #FFFFFF;
 
     &.chosen {
-      background-color: #FFFFFF;
       &:before {
         content: "";
         position: absolute;

--- a/components/src/PurchaseOrderWidget/purchase.order.widget.less
+++ b/components/src/PurchaseOrderWidget/purchase.order.widget.less
@@ -37,7 +37,7 @@
   }
   
   .pay-with-po-btn {
-    margin-top: 30px;
+    margin-top: 45px;
   }
 
   .form-control {

--- a/components/src/PurchaseOrderWidget/purchase.order.widget.less
+++ b/components/src/PurchaseOrderWidget/purchase.order.widget.less
@@ -65,4 +65,27 @@
     margin-top:2px;
     right: 30px;
   }
+
+  .checkmark {
+    position: relative;
+    margin-top: 10px;
+    width: 18px;
+    height: 18px;
+
+    &.chosen {
+      background-color: #FFFFFF;
+      &:before {
+        content: "";
+        position: absolute;
+        top: 10px;
+        left: -1px;
+        width: 12px;
+        height: 7px;
+        border: solid 2px #6dd401;
+        border-right: none;
+        border-top: none;
+        transform: translate(2px, 1px) rotate(-45deg);
+      }
+    }
+  }
 }

--- a/components/src/PurchaseOrderWidget/purchase.order.widget.stories.tsx
+++ b/components/src/PurchaseOrderWidget/purchase.order.widget.stories.tsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright © 2019 Elastic Path Software Inc. All rights reserved.
+ *
+ * This is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this license. If not, see
+ *
+ *     https://www.gnu.org/licenses/
+ *
+ *
+ */
+import React from 'react';
+import Readme from './README.md';
+import { storiesOf } from '@storybook/react';
+import { MemoryRouter } from 'react-router';
+import { object, text } from "@storybook/addon-knobs/react";
+import { textToFunc } from "../../../storybook/utils/storybookUtils"
+import PurchaseOrderWidget from './purchase.order.widget';
+
+storiesOf('Components|PurchaseOrderWidget', module)
+  .addParameters({
+    readme: {
+      // Show readme at the addons panel
+      sidebar: Readme,
+    },
+  })
+  .addDecorator(story => (
+    <MemoryRouter initialEntries={['/']}>{story()}</MemoryRouter>
+  ))
+  .add('Purchase Order Widget', () => {
+    return <PurchaseOrderWidget />;
+  });

--- a/components/src/PurchaseOrderWidget/purchase.order.widget.stories.tsx
+++ b/components/src/PurchaseOrderWidget/purchase.order.widget.stories.tsx
@@ -37,5 +37,5 @@ storiesOf('Components|PurchaseOrderWidget', module)
     <MemoryRouter initialEntries={['/']}>{story()}</MemoryRouter>
   ))
   .add('Purchase Order Widget', () => {
-    return <PurchaseOrderWidget />;
+    return <PurchaseOrderWidget timeoutBeforeVerify={1000} />;
   });

--- a/components/src/PurchaseOrderWidget/purchase.order.widget.stories.tsx
+++ b/components/src/PurchaseOrderWidget/purchase.order.widget.stories.tsx
@@ -37,5 +37,11 @@ storiesOf('Components|PurchaseOrderWidget', module)
     <MemoryRouter initialEntries={['/']}>{story()}</MemoryRouter>
   ))
   .add('Purchase Order Widget', () => {
-    return <PurchaseOrderWidget timeoutBeforeVerify={1000} />;
+    const onPayWithPOFuncText = text('onPayWithPO', '() => {alert("onPayWithPO invoked")}');
+    const onViewClickedFuncText = text('onViewClicked', '() => {alert("onViewClicked invoked")}');
+    return <PurchaseOrderWidget
+      timeoutBeforeVerify={1000}
+      onPayWithPO={() => { textToFunc(onPayWithPOFuncText); }}
+      onViewClicked={() => { textToFunc(onViewClickedFuncText); }}
+    />;
   });

--- a/components/src/PurchaseOrderWidget/purchase.order.widget.tsx
+++ b/components/src/PurchaseOrderWidget/purchase.order.widget.tsx
@@ -95,6 +95,7 @@ class PurchaseOrderWidget extends React.Component<PurchaseOrderWidgetProps, Purc
       const timeID = setTimeout(() => {
         this.verifyPONumber();
       }, timeoutBeforeVerify);
+      this.setState({ inputStatus: 'loading' });
       isTypingTimer = timeID;
     }
   }
@@ -105,12 +106,12 @@ class PurchaseOrderWidget extends React.Component<PurchaseOrderWidgetProps, Purc
     switch (inputStatus) {
       case 'loading':
         return (
-          <div className="miniLoader-container">
-            <div className="miniLoader" />
+          <div className="inputLoader-container">
+            <div className="inputLoader" />
           </div>);
       case 'verified':
         return (
-          <div className="miniLoader-container">
+          <div className="inputLoader-container">
             <div className="checkmark chosen" />
           </div>);
       default:

--- a/components/src/PurchaseOrderWidget/purchase.order.widget.tsx
+++ b/components/src/PurchaseOrderWidget/purchase.order.widget.tsx
@@ -21,6 +21,7 @@
 
 import React from 'react';
 import intl from 'react-intl-universal';
+import { Messagecontainer } from '@elasticpath/store-components';
 import { login } from '../utils/AuthService';
 import { cortexFetch } from '../utils/Cortex';
 import { getConfig, IEpConfig } from '../utils/ConfigProvider';
@@ -112,11 +113,6 @@ class PurchaseOrderWidget extends React.Component<PurchaseOrderWidgetProps, Purc
           <div className="miniLoader-container">
             <div className="checkmark chosen" />
           </div>);
-      case 'error':
-        return (
-          <div className="miniLoader-container">
-            <div className="miniLoader" />
-          </div>);
       default:
         return null;
     }
@@ -124,11 +120,25 @@ class PurchaseOrderWidget extends React.Component<PurchaseOrderWidgetProps, Purc
 
   // eslint-disable-next-line class-methods-use-this
   renderPurchaseOrderTextBox() {
-    const { inputTextValue } = this.state;
+    const { inputTextValue, inputStatus } = this.state;
+    const warningMessage = {
+      debugMessages: 'Invalid PO number',
+      type: 'error',
+      id: 'field.invalid.email.format',
+    };
     return (
-      <div className="purchase-order-widget-input-container">
-        <input value={inputTextValue} className="form-control" type="text" placeholder="Enter Purchase Order Number (PO)" onChange={this.updateInputState} onKeyUp={this.startValidationTimer} onKeyDown={this.clearIsTypingTimer} />
-        {this.renderInputStatus()}
+      <div>
+        <div className="purchase-order-widget-input-container">
+          <input value={inputTextValue} className="form-control" type="text" placeholder="Enter Purchase Order Number (PO)" onChange={this.updateInputState} onKeyUp={this.startValidationTimer} onKeyDown={this.clearIsTypingTimer} />
+          {this.renderInputStatus()}
+        </div>
+        {
+          inputStatus === 'error' && (
+            <div>
+              <Messagecontainer message={[warningMessage]} />
+            </div>
+          )
+        }
       </div>
     );
   }

--- a/components/src/PurchaseOrderWidget/purchase.order.widget.tsx
+++ b/components/src/PurchaseOrderWidget/purchase.order.widget.tsx
@@ -36,6 +36,7 @@ const POInputStates = {
   ERROR: 'ERROR',
 };
 
+// NOTE: Remove this when using this component in a real implementation! only here to simulate PO number validation.
 const dummyValidPONumbers = new Set(['1234', '2345', '3456']);
 
 interface PurchaseOrderWidgetState {
@@ -79,6 +80,7 @@ class PurchaseOrderWidget extends React.Component<PurchaseOrderWidgetProps, Purc
   verifyPONumber() {
     const { inputTextValue } = this.state;
 
+    // NOTE: This should be replaced with a network request to validate the PO number entered.  A timeout is placed here as a placeholder.
     setTimeout(() => {
       if (dummyValidPONumbers.has(inputTextValue)) {
         this.setState({ inputStatus: POInputStates.VERIFIED });
@@ -120,7 +122,6 @@ class PurchaseOrderWidget extends React.Component<PurchaseOrderWidgetProps, Purc
     }
   }
 
-  // eslint-disable-next-line class-methods-use-this
   renderPurchaseOrderTextBox() {
     const { inputTextValue, inputStatus } = this.state;
     const warningMessage = {

--- a/components/src/PurchaseOrderWidget/purchase.order.widget.tsx
+++ b/components/src/PurchaseOrderWidget/purchase.order.widget.tsx
@@ -30,6 +30,12 @@ import './purchase.order.widget.less';
 let Config: IEpConfig | any = {};
 let isTypingTimer = null;
 
+const POInputStates = {
+  LOADING: 'LOADING',
+  VERIFIED: 'VERIFIED',
+  ERROR: 'ERROR',
+};
+
 const dummyValidPONumbers = new Set(['1234', '2345', '3456']);
 
 interface PurchaseOrderWidgetState {
@@ -58,11 +64,9 @@ class PurchaseOrderWidget extends React.Component<PurchaseOrderWidgetProps, Purc
     this.updateInputState = this.updateInputState.bind(this);
   }
 
-  // TODO: resets the typing timer.
   clearIsTypingTimer(event) {
     if (isTypingTimer != null) {
-      // eslint-disable-next-line react/no-unused-state
-      this.setState({ inputStatus: 'loading' });
+      this.setState({ inputStatus: POInputStates.LOADING });
       clearTimeout(isTypingTimer);
       isTypingTimer = null;
     }
@@ -74,28 +78,25 @@ class PurchaseOrderWidget extends React.Component<PurchaseOrderWidgetProps, Purc
 
   verifyPONumber() {
     const { inputTextValue } = this.state;
-    console.log('timeout ended so we can validate the po number');
-    // TODO: write dummy PO number validation...
+
     setTimeout(() => {
       if (dummyValidPONumbers.has(inputTextValue)) {
-        // We need to a couple states for the input bar...
-        this.setState({ inputStatus: 'verified' });
+        this.setState({ inputStatus: POInputStates.VERIFIED });
       } else {
-        this.setState({ inputStatus: 'error' });
+        this.setState({ inputStatus: POInputStates.ERROR });
       }
     }, 1000);
 
     isTypingTimer = null;
   }
 
-  // TODO: This function will verify and return everytime there is a change...
   startValidationTimer(event) {
     const { timeoutBeforeVerify } = this.props;
     if (isTypingTimer == null) {
       const timeID = setTimeout(() => {
         this.verifyPONumber();
       }, timeoutBeforeVerify);
-      this.setState({ inputStatus: 'loading' });
+      this.setState({ inputStatus: POInputStates.LOADING });
       isTypingTimer = timeID;
     }
   }
@@ -104,12 +105,12 @@ class PurchaseOrderWidget extends React.Component<PurchaseOrderWidgetProps, Purc
     const { inputStatus } = this.state;
 
     switch (inputStatus) {
-      case 'loading':
+      case POInputStates.LOADING:
         return (
           <div className="inputLoader-container">
             <div className="inputLoader" />
           </div>);
-      case 'verified':
+      case POInputStates.VERIFIED:
         return (
           <div className="inputLoader-container">
             <div className="checkmark chosen" />
@@ -134,7 +135,7 @@ class PurchaseOrderWidget extends React.Component<PurchaseOrderWidgetProps, Purc
           {this.renderInputStatus()}
         </div>
         {
-          inputStatus === 'error' && (
+          inputStatus === POInputStates.ERROR && (
             <div>
               <Messagecontainer message={[warningMessage]} />
             </div>

--- a/components/src/PurchaseOrderWidget/purchase.order.widget.tsx
+++ b/components/src/PurchaseOrderWidget/purchase.order.widget.tsx
@@ -147,15 +147,25 @@ class PurchaseOrderWidget extends React.Component<PurchaseOrderWidgetProps, Purc
   }
 
   render() {
+    const { inputStatus } = this.state;
+
     return (
       <div className="purchase-order-widget-container">
         <div className="purchase-order-widget-top">
           <h2>
             {'Purchase Order'}
           </h2>
-          <button className="view-button-inactive" disabled type="button" onClick={() => { }}>
-            {'View'}
-          </button>
+          {
+            inputStatus === POInputStates.VERIFIED ? (
+              <button className="view-button active" type="button" onClick={() => { }}>
+                {'View'}
+              </button>
+            ) : (
+              <button className="view-button inactive" disabled type="button" onClick={() => { }}>
+                {'View'}
+              </button>
+            )
+          }
         </div>
         <div data-region="paymentMethodSelectorsRegion" className="checkout-region-inner-container">
           {this.renderPurchaseOrderTextBox()}

--- a/components/src/PurchaseOrderWidget/purchase.order.widget.tsx
+++ b/components/src/PurchaseOrderWidget/purchase.order.widget.tsx
@@ -1,0 +1,72 @@
+/**
+ * Copyright © 2019 Elastic Path Software Inc. All rights reserved.
+ *
+ * This is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this license. If not, see
+ *
+ *     https://www.gnu.org/licenses/
+ *
+ *
+ */
+
+import React from 'react';
+import intl from 'react-intl-universal';
+import { login } from '../utils/AuthService';
+import { cortexFetch } from '../utils/Cortex';
+import { getConfig, IEpConfig } from '../utils/ConfigProvider';
+import './purchase.order.widget.less';
+
+let Config: IEpConfig | any = {};
+
+interface PurchaseOrderWidgetState {
+}
+
+interface PurchaseOrderWidgetProps {
+}
+
+class PurchaseOrderWidget extends React.Component<PurchaseOrderWidgetProps, PurchaseOrderWidgetState> {
+  constructor(props) {
+    super(props);
+    const epConfig = getConfig();
+    Config = epConfig.config;
+    this.renderPurchaseOrderTextBox = this.renderPurchaseOrderTextBox.bind(this);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  renderPurchaseOrderTextBox() {
+    // TODO:
+    return (<input id="CardHolderName" name="CardHolderName" className="form-control" type="text" placeholder="Enter Purchase Order Number (PO)" />);
+  }
+
+  render() {
+    return (
+      <div className="purchase-order-widget-container">
+        <div className="purchase-order-widget-top">
+          <h2>
+            {'Purchase Order'}
+          </h2>
+          <button className="view-button-inactive" disabled type="button" onClick={() => { console.log('clicked'); }}>
+            {'View'}
+          </button>
+        </div>
+        <div data-region="paymentMethodSelectorsRegion" className="checkout-region-inner-container">
+          {this.renderPurchaseOrderTextBox()}
+        </div>
+        <button className="ep-btn primary wide pay-with-po-btn" disabled={false} type="button" onClick={() => {}}>
+          {'Pay with PO'}
+        </button>
+      </div>);
+  }
+}
+
+export default PurchaseOrderWidget;

--- a/components/src/PurchaseOrderWidget/purchase.order.widget.tsx
+++ b/components/src/PurchaseOrderWidget/purchase.order.widget.tsx
@@ -153,7 +153,7 @@ class PurchaseOrderWidget extends React.Component<PurchaseOrderWidgetProps, Purc
           <h2>
             {'Purchase Order'}
           </h2>
-          <button className="view-button-inactive" disabled type="button" onClick={() => { console.log('clicked'); }}>
+          <button className="view-button-inactive" disabled type="button" onClick={() => { }}>
             {'View'}
           </button>
         </div>

--- a/components/src/PurchaseOrderWidget/purchase.order.widget.tsx
+++ b/components/src/PurchaseOrderWidget/purchase.order.widget.tsx
@@ -45,7 +45,9 @@ interface PurchaseOrderWidgetState {
 }
 
 interface PurchaseOrderWidgetProps {
-  timeoutBeforeVerify: number;
+  timeoutBeforeVerify: number,
+  onPayWithPO: (...args: any[]) => any,
+  onViewClicked?: (...args: any[]) => any,
 }
 
 class PurchaseOrderWidget extends React.Component<PurchaseOrderWidgetProps, PurchaseOrderWidgetState> {
@@ -63,6 +65,7 @@ class PurchaseOrderWidget extends React.Component<PurchaseOrderWidgetProps, Purc
     this.verifyPONumber = this.verifyPONumber.bind(this);
     this.renderInputStatus = this.renderInputStatus.bind(this);
     this.updateInputState = this.updateInputState.bind(this);
+    this.showMorePODetails = this.showMorePODetails.bind(this);
   }
 
   clearIsTypingTimer(event) {
@@ -146,8 +149,19 @@ class PurchaseOrderWidget extends React.Component<PurchaseOrderWidgetProps, Purc
     );
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  showMorePODetails() {
+    // TODO: Need to implement function that shows the PO details modal.
+    const { onViewClicked } = this.props;
+
+    if (onViewClicked) {
+      onViewClicked();
+    }
+  }
+
   render() {
     const { inputStatus } = this.state;
+    const { onPayWithPO } = this.props;
 
     return (
       <div className="purchase-order-widget-container">
@@ -157,11 +171,11 @@ class PurchaseOrderWidget extends React.Component<PurchaseOrderWidgetProps, Purc
           </h2>
           {
             inputStatus === POInputStates.VERIFIED ? (
-              <button className="view-button active" type="button" onClick={() => { }}>
+              <button className="view-button active" type="button" onClick={this.showMorePODetails}>
                 {'View'}
               </button>
             ) : (
-              <button className="view-button inactive" disabled type="button" onClick={() => { }}>
+              <button className="view-button inactive" disabled type="button" onClick={this.showMorePODetails}>
                 {'View'}
               </button>
             )
@@ -170,7 +184,7 @@ class PurchaseOrderWidget extends React.Component<PurchaseOrderWidgetProps, Purc
         <div data-region="paymentMethodSelectorsRegion" className="checkout-region-inner-container">
           {this.renderPurchaseOrderTextBox()}
         </div>
-        <button className="ep-btn primary wide pay-with-po-btn" disabled={false} type="button" onClick={() => {}}>
+        <button className="ep-btn primary wide pay-with-po-btn" disabled={false} type="button" onClick={onPayWithPO}>
           {'Pay with PO'}
         </button>
       </div>);

--- a/components/src/PurchaseOrderWidget/purchase.order.widget.tsx
+++ b/components/src/PurchaseOrderWidget/purchase.order.widget.tsx
@@ -27,11 +27,15 @@ import { getConfig, IEpConfig } from '../utils/ConfigProvider';
 import './purchase.order.widget.less';
 
 let Config: IEpConfig | any = {};
+let isTypingTimer = null;
 
 interface PurchaseOrderWidgetState {
+  isLoading: boolean,
+  PONumber: string;
 }
 
 interface PurchaseOrderWidgetProps {
+  timeoutBeforeVerify: number;
 }
 
 class PurchaseOrderWidget extends React.Component<PurchaseOrderWidgetProps, PurchaseOrderWidgetState> {
@@ -39,13 +43,52 @@ class PurchaseOrderWidget extends React.Component<PurchaseOrderWidgetProps, Purc
     super(props);
     const epConfig = getConfig();
     Config = epConfig.config;
+    this.state = {
+      isLoading: true,
+      PONumber: null,
+    };
     this.renderPurchaseOrderTextBox = this.renderPurchaseOrderTextBox.bind(this);
+    this.startValidationTimer = this.startValidationTimer.bind(this);
+    this.clearIsTypingTimer = this.clearIsTypingTimer.bind(this);
+  }
+
+  // TODO: resets the typing timer.
+  clearIsTypingTimer() {
+    if (isTypingTimer != null) {
+      // eslint-disable-next-line react/no-unused-state
+      this.setState({ isLoading: false });
+      clearTimeout(isTypingTimer);
+      isTypingTimer = null;
+    }
+  }
+
+  // TODO: This function will verify and return everytime there is a change...
+  startValidationTimer() {
+    const { timeoutBeforeVerify } = this.props;
+    const verifyPONumberHelper = () => {
+      console.log('timeout ended so we can validate the po number');
+      this.setState({ isLoading: true });
+      isTypingTimer = null;
+    };
+
+    // if the typing timer has not been set or one does not currently exist.
+    if (isTypingTimer == null) {
+      const timeID = setTimeout(verifyPONumberHelper, timeoutBeforeVerify);
+      isTypingTimer = timeID;
+    }
   }
 
   // eslint-disable-next-line class-methods-use-this
   renderPurchaseOrderTextBox() {
     // TODO:
-    return (<input id="CardHolderName" name="CardHolderName" className="form-control" type="text" placeholder="Enter Purchase Order Number (PO)" />);
+    return (
+      <div className="purchase-order-widget-input-container">
+        <input className="form-control" type="text" placeholder="Enter Purchase Order Number (PO)" onKeyUp={this.startValidationTimer} onKeyDown={this.clearIsTypingTimer} />
+        <div className="miniLoader-container">
+          <div className="miniLoader" />
+        </div>
+      </div>
+    );
   }
 
   render() {

--- a/components/src/PurchaseOrderWidget/purchase.order.widget.tsx
+++ b/components/src/PurchaseOrderWidget/purchase.order.widget.tsx
@@ -29,9 +29,11 @@ import './purchase.order.widget.less';
 let Config: IEpConfig | any = {};
 let isTypingTimer = null;
 
+const dummyValidPONumbers = new Set(['1234', '2345', '3456']);
+
 interface PurchaseOrderWidgetState {
-  isLoading: boolean,
-  PONumber: string;
+  inputStatus: string,
+  inputTextValue: string,
 }
 
 interface PurchaseOrderWidgetProps {
@@ -44,49 +46,89 @@ class PurchaseOrderWidget extends React.Component<PurchaseOrderWidgetProps, Purc
     const epConfig = getConfig();
     Config = epConfig.config;
     this.state = {
-      isLoading: true,
-      PONumber: null,
+      inputStatus: '',
+      inputTextValue: '',
     };
     this.renderPurchaseOrderTextBox = this.renderPurchaseOrderTextBox.bind(this);
     this.startValidationTimer = this.startValidationTimer.bind(this);
     this.clearIsTypingTimer = this.clearIsTypingTimer.bind(this);
+    this.verifyPONumber = this.verifyPONumber.bind(this);
+    this.renderInputStatus = this.renderInputStatus.bind(this);
+    this.updateInputState = this.updateInputState.bind(this);
   }
 
   // TODO: resets the typing timer.
-  clearIsTypingTimer() {
+  clearIsTypingTimer(event) {
     if (isTypingTimer != null) {
       // eslint-disable-next-line react/no-unused-state
-      this.setState({ isLoading: false });
+      this.setState({ inputStatus: 'loading' });
       clearTimeout(isTypingTimer);
       isTypingTimer = null;
     }
   }
 
-  // TODO: This function will verify and return everytime there is a change...
-  startValidationTimer() {
-    const { timeoutBeforeVerify } = this.props;
-    const verifyPONumberHelper = () => {
-      console.log('timeout ended so we can validate the po number');
-      this.setState({ isLoading: true });
-      isTypingTimer = null;
-    };
+  updateInputState(event) {
+    this.setState({ inputTextValue: event.target.value });
+  }
 
-    // if the typing timer has not been set or one does not currently exist.
+  verifyPONumber() {
+    const { inputTextValue } = this.state;
+    console.log('timeout ended so we can validate the po number');
+    // TODO: write dummy PO number validation...
+    setTimeout(() => {
+      if (dummyValidPONumbers.has(inputTextValue)) {
+        // We need to a couple states for the input bar...
+        this.setState({ inputStatus: 'verified' });
+      } else {
+        this.setState({ inputStatus: 'error' });
+      }
+    }, 1000);
+
+    isTypingTimer = null;
+  }
+
+  // TODO: This function will verify and return everytime there is a change...
+  startValidationTimer(event) {
+    const { timeoutBeforeVerify } = this.props;
     if (isTypingTimer == null) {
-      const timeID = setTimeout(verifyPONumberHelper, timeoutBeforeVerify);
+      const timeID = setTimeout(() => {
+        this.verifyPONumber();
+      }, timeoutBeforeVerify);
       isTypingTimer = timeID;
+    }
+  }
+
+  renderInputStatus() {
+    const { inputStatus } = this.state;
+
+    switch (inputStatus) {
+      case 'loading':
+        return (
+          <div className="miniLoader-container">
+            <div className="miniLoader" />
+          </div>);
+      case 'verified':
+        return (
+          <div className="miniLoader-container">
+            <div className="checkmark chosen" />
+          </div>);
+      case 'error':
+        return (
+          <div className="miniLoader-container">
+            <div className="miniLoader" />
+          </div>);
+      default:
+        return null;
     }
   }
 
   // eslint-disable-next-line class-methods-use-this
   renderPurchaseOrderTextBox() {
-    // TODO:
+    const { inputTextValue } = this.state;
     return (
       <div className="purchase-order-widget-input-container">
-        <input className="form-control" type="text" placeholder="Enter Purchase Order Number (PO)" onKeyUp={this.startValidationTimer} onKeyDown={this.clearIsTypingTimer} />
-        <div className="miniLoader-container">
-          <div className="miniLoader" />
-        </div>
+        <input value={inputTextValue} className="form-control" type="text" placeholder="Enter Purchase Order Number (PO)" onChange={this.updateInputState} onKeyUp={this.startValidationTimer} onKeyDown={this.clearIsTypingTimer} />
+        {this.renderInputStatus()}
       </div>
     );
   }

--- a/components/src/PurchaseOrderWidget/purchase.order.widget.tsx
+++ b/components/src/PurchaseOrderWidget/purchase.order.widget.tsx
@@ -128,7 +128,7 @@ class PurchaseOrderWidget extends React.Component<PurchaseOrderWidgetProps, Purc
   renderPurchaseOrderTextBox() {
     const { inputTextValue, inputStatus } = this.state;
     const warningMessage = {
-      debugMessages: 'Invalid PO number',
+      debugMessages: intl.get('invalid-po-number'),
       type: 'error',
       id: 'field.invalid.email.format',
     };
@@ -167,16 +167,16 @@ class PurchaseOrderWidget extends React.Component<PurchaseOrderWidgetProps, Purc
       <div className="purchase-order-widget-container">
         <div className="purchase-order-widget-top">
           <h2>
-            {'Purchase Order'}
+            { intl.get('purchase-order') }
           </h2>
           {
             inputStatus === POInputStates.VERIFIED ? (
               <button className="view-button active" type="button" onClick={this.showMorePODetails}>
-                {'View'}
+                { intl.get('view') }
               </button>
             ) : (
               <button className="view-button inactive" disabled type="button" onClick={this.showMorePODetails}>
-                {'View'}
+                { intl.get('view') }
               </button>
             )
           }
@@ -185,7 +185,7 @@ class PurchaseOrderWidget extends React.Component<PurchaseOrderWidgetProps, Purc
           {this.renderPurchaseOrderTextBox()}
         </div>
         <button className="ep-btn primary wide pay-with-po-btn" disabled={false} type="button" onClick={onPayWithPO}>
-          {'Pay with PO'}
+          { intl.get('pay-with-po') }
         </button>
       </div>);
   }

--- a/components/src/index.ts
+++ b/components/src/index.ts
@@ -87,6 +87,7 @@ import B2bAddAssociatesMenu from './B2bAddAssociatesMenu/b2b.addassociatesmenu';
 import B2bEditAssociate from './B2bEditAssociate/b2b.editassociate';
 import B2bSideMenu from './B2bSideMenu/b2b.sidemenu';
 import CartClear from './CartClear/cartclear';
+import PurchaseOrderWidget from './PurchaseOrderWidget/purchase.order.widget';
 import { CountProvider } from './cart-count-context';
 
 export {
@@ -159,4 +160,5 @@ export {
   B2bSideMenu,
   CartClear,
   CountProvider,
+  PurchaseOrderWidget,
 };

--- a/components/webpack.config.base.js
+++ b/components/webpack.config.base.js
@@ -21,7 +21,6 @@
 const path = require('path');
 
 module.exports = {
-  devtool: 'source-map',
   mode: 'production',
   entry: './src/index',
   module: {


### PR DESCRIPTION
Description:
<!--A brief description of changes. Things to include: WIP? Dependent PR's opened against other tickets? -->

This creates a new PO number entry component.  It can be tested and interacted with in storybook.  It has not been consumed in the actual application yet.

Before that is done we should 

1. refactor out all the widgets or forms on the checkout page into components.  will make consumption easier.  

2. Implement the the PONumber modal that is to be viewed via the `view button` in the component.  (Designs just changed. May not need this step)

Also note that the webpack config for building components has been altered to remove source-map generation.  This fixes an error with node where the heap would run out of space.


NOTE: This was branched off before the mono repo change was merged.  Will need to rebase these changes on top before merging this branch.

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Component Updates:
<!--Have you updated components/package.json and components/package-lock.json for any components that have been updated? -->
- [ ] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [ ] Manual tests

Tests have all been done in storybook and is behaving as planned.

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
