### PR TITLE
Fix reorder check

### DIFF
--- a/src/components/package-lock.json
+++ b/src/components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/store-components",
-  "version": "1.1.55",
+  "version": "1.1.57",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/package.json
+++ b/src/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/store-components",
-  "version": "1.1.56",
+  "version": "1.1.57",
   "main": "build/cjs/index",
   "main:src": "src/index",
   "types": "build/types/components/src/index",

--- a/src/components/src/Reorder/reorder.main.tsx
+++ b/src/components/src/Reorder/reorder.main.tsx
@@ -117,7 +117,7 @@ class ReorderMain extends Component<ReorderMainProps, ReorderMainState> {
     const { productsData } = this.props;
     productsData._lineitems[0]._element.forEach((product) => {
       const SKUCode = product._item[0]._code[0].code;
-      const isConfigurable = product._item[0]._definition[0].links.find(link => link.rel === 'options');
+      const isConfigurable = product._item[0]._addtocartform[0].configuration && Object.entries(product._item[0]._addtocartform[0].configuration).length > 0;
 
       if (isConfigurable) {
         this.handleError(SKUCode, intl.get('configurable-product-message', { SKUCode }));


### PR DESCRIPTION
Description:
The check that exists in the reorder component is currently checking whether or not the product has variants (is multi-SKU) and prevents adding to cart based on this criteria.  I have altered the check to see whether or not the product has Cart Item Modifiers, which is the limitation imposed by the API.

This is a similar fix to https://github.com/elasticpath/react-pwa-reference-storefront/pull/447


Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Component Updates:
<!--Have you updated components/package.json and components/package-lock.json for any components that have been updated? -->
- [x] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests
1. Succesfully re-ordered multi-SKU products
2. Was prevented from ordering configurable products

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
