### PR TITLE
Add back shopper impersonation banner

### DIFF
--- a/src/components/package.json
+++ b/src/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/store-components",
-  "version": "1.1.58",
+  "version": "1.1.59",
   "main": "build/cjs/index",
   "main:src": "src/index",
   "types": "build/types/components/src/index",

--- a/src/components/src/AppHeader/appheader.main.less
+++ b/src/components/src/AppHeader/appheader.main.less
@@ -41,6 +41,15 @@
     fill: @mainTextColor;
   }
 
+  .impersonation-notification {
+    height: 100%;
+    background-color: #8b1e24;
+    text-align: center;
+    color: @mainNavigationColor;
+    padding: 2px 0;
+    font-weight: 700;
+  }
+
   .main-container {
     position: relative;
     min-height: 60px;

--- a/src/components/src/AppHeader/appheader.main.tsx
+++ b/src/components/src/AppHeader/appheader.main.tsx
@@ -255,6 +255,8 @@ class AppHeaderMain extends Component<AppHeaderMainProps, AppHeaderMainState> {
       appModalLoginLinks,
     } = this.props;
     const availability = Boolean(cartData);
+    const impersonating = localStorage.getItem(`${Config.cortexApi.scope}_oAuthImpersonationToken`);
+    const userName = localStorage.getItem(`${Config.cortexApi.scope}_oAuthUserName`) || localStorage.getItem(`${Config.cortexApi.scope}_oAuthUserId`);
 
     const Cart = () => {
       const { count, name }: any = useCountState();
@@ -278,7 +280,14 @@ class AppHeaderMain extends Component<AppHeaderMainProps, AppHeaderMainState> {
 
     return [
       <header key="app-header" className="app-header">
-
+        {
+          impersonating ? (
+            <div className="impersonation-notification">
+              {intl.get('shopper-impersonation-message')}
+              {userName}
+            </div>
+          ) : ''
+        }
         <div className={`main-container ${isInStandaloneMode ? 'in-standalone' : ''}`}>
 
           <div className="main-container-col">


### PR DESCRIPTION
Description:
<!--A brief description of changes. Things to include: WIP? Dependent PR's opened against other tickets? -->
This adds back the shopper impersonation banner into the reference store as the component that used the shopper impersonation banner is no longer being used. 

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Component Updates:
<!--Have you updated components/package.json and components/package-lock.json for any components that have been updated? -->
- [x] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
