### PR TITLE
Fixed conflicting css for control-label

### DIFF
--- a/src/components/src/QuickOrderForm/quickorderform.less
+++ b/src/components/src/QuickOrderForm/quickorderform.less
@@ -42,19 +42,19 @@
 .bulk-item {
   display: flex;
   align-items: flex-end;
-}
-.bulk-item-col {
-  display: inline-block;
-}
+  .bulk-item-col {
+    display: inline-block;
+  }
 
-.control-label {
-  height: 15px;
-  width: 100%;
-  margin: 22px 0 0;
-  color: @firstComplimentTextColor;
-  font-size: 12px;
-  text-transform: uppercase;
-  font-weight: bold;
+  .control-label {
+    height: 15px;
+    width: 100%;
+    margin: 22px 0 0;
+    color: @firstComplimentTextColor;
+    font-size: 12px;
+    text-transform: uppercase;
+    font-weight: bold;
+  }
 }
 
 .input-group-btn {


### PR DESCRIPTION
Description:
<!--A brief description of changes. Things to include: WIP? Dependent PR's opened against other tickets? -->
Styling for `.control-label` was not parented properly in the quickorderform.less. As a result the styling applied throughout the project and messed up the formatting of cart item modifier control-label. This PR parents the styles so that it does not affect other components with the same class styles. 

Confirm:
- quickorderform labels styles are applied to quick order form labels (and no where else)
- confirm labels for cart item modifiers aren't misaligned

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Component Updates:
<!--Have you updated components/package.json and components/package-lock.json for any components that have been updated? -->
- [x] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
