### PR TITLE
Fix: OrderHistoryPage.tsx showing blank on B2B deployments

### DIFF
--- a/src/utils/CortexLookup.ts
+++ b/src/utils/CortexLookup.ts
@@ -181,6 +181,7 @@ const itemFormZoomArray = [
 const purchaseFormZoomArray = [
   'paymentmeans:element',
   'postedpayments:element',
+  'paymentinstruments:element',
   'shipments:element:destination',
   'shipments:element:shippingoption',
   'billingaddress',


### PR DESCRIPTION
Description:

On our test B2B deployments, navigating to the OrderHistoryPage was crashing the app (log in > navigate to profile > click on a previous order number). The specific error was:

> cannot read property "0" of undefined at [`purchasedetails.main.tsx:123`](https://github.com/elasticpath/react-pwa-reference-storefront/blob/99f7e7ad1b682d081c8de48b067bdb28fe06a39c/src/components/src/PurchaseDetails/purchasedetails.main.tsx#L116).

This was occurring because the zoom array used by `CortexLookup.ts#purchaseLookup` didn't include the `paymentinstruments` resource in its zoom.

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Component Updates:
<!--Have you updated components/package.json and components/package-lock.json for any components that have been updated? -->
- [ ] Component package requires update on npm [@elasticpath/store-components](https://www.npmjs.com/package/@elasticpath/store-components)

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests

I confirmed that this fixes the issue we were having. It's just a zoom addition, so I didn't bother running e2e tests.

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
