### PR TITLE
Lazy load b2b Bulk Order & Barcode Scanner

### DIFF
--- a/src/components/src/AppHeader/appheader.main.tsx
+++ b/src/components/src/AppHeader/appheader.main.tsx
@@ -19,7 +19,7 @@
  *
  */
 
-import React, { Component } from 'react';
+import React, { Component, Suspense, lazy } from 'react';
 import intl from 'react-intl-universal';
 import { Link } from 'react-router-dom';
 import AppHeaderSearchMain from '../AppHeaderSearch/appheadersearch.main';
@@ -27,7 +27,6 @@ import BloomreachAppHeaderSearchMain from '../Bloomreach/bloomreach.appheadersea
 import AppHeaderLoginMain from '../AppHeaderLogin/appheaderlogin.main';
 import AppHeaderLocaleMain from '../AppHeaderLocale/appheaderlocale.main';
 import AppHeaderNavigationMain from '../AppHeaderNavigation/appheadernavigation.main';
-import BulkOrderMain from '../BulkOrder/bulkorder.main';
 import CountInfoPopUp from '../CountInfoPopUp/countinfopopup';
 import { useCountState } from '../cart-count-context';
 import { cortexFetch } from '../utils/Cortex';
@@ -107,6 +106,9 @@ interface AppHeaderMainState {
   isLoggedInUser: boolean,
   totalQuantity: number,
 }
+
+const BulkOrderImport = Config.b2b.enable ? import(/* webpackChunkName: "bulkorder" */ '../BulkOrder/bulkorder.main') : null;
+const BulkOrderMain = lazy(() => BulkOrderImport);
 
 class AppHeaderMain extends Component<AppHeaderMainProps, AppHeaderMainState> {
   static defaultProps = {
@@ -391,7 +393,11 @@ class AppHeaderMain extends Component<AppHeaderMainProps, AppHeaderMainState> {
             <div className="locale-container">
               <AppHeaderLocaleMain onCurrencyChange={onCurrencyChange} onLocaleChange={onLocaleChange} />
             </div>
-            {Config.b2b.enable && <BulkOrderMain isBulkModalOpened={isBulkModalOpened} handleClose={this.handleBulkModalClose} cartData={cartData} />}
+            {Config.b2b.enable && (
+              <Suspense fallback={<div />}>
+                <BulkOrderMain isBulkModalOpened={isBulkModalOpened} handleClose={this.handleBulkModalClose} cartData={cartData} />
+              </Suspense>)
+            }
           </div>
         </div>
 

--- a/src/components/src/BarcodeScanner/barcodescanner.tsx
+++ b/src/components/src/BarcodeScanner/barcodescanner.tsx
@@ -62,10 +62,6 @@ class BarcodeScanner extends Component<BarcodeScannerProps, BarcodeScannerState>
     this.stopScanning();
   }
 
-  static checkAvailability(): boolean {
-    return Boolean(navigator && navigator.mediaDevices);
-  }
-
   initScanner() {
     const scannerContainer = this.scannerContainer.current;
     Quagga.init({

--- a/src/components/src/index.ts
+++ b/src/components/src/index.ts
@@ -34,7 +34,6 @@ import AppHeaderTopMain from './AppHeaderTop/appheadertop.main';
 import AppModalBundleConfigurationMain from './AppModalBundleConfiguration/appmodalbundleconfiguration.main';
 import AppModalCartSelectMain from './AppModalCartSelect/appmodalcartselect.main';
 import AppModalLoginMain from './AppModalLogin/appmodallogin.main';
-import BulkOrderMain from './BulkOrder/bulkorder.main';
 import BundleConstituentsDisplayMain from './BundleConstituents/bundleconstituents.main';
 import B2bAccountList from './B2bAccountList/b2b.accountlist';
 import B2bAddProductsModal from './B2bAddProductsModal/b2b.add.products.modal';
@@ -85,7 +84,6 @@ import SearchResultsItemsMain from './SearchResultsItems/searchresultsitems.main
 import ShippingOptionContainer from './ShippingOption/shippingoption.container';
 import SortProductMenu from './SortProductMenu/sortproductmenu.main';
 import WishListMain from './WishList/wishlist.main';
-import BarcodeScanner from './BarcodeScanner/barcodescanner';
 import CartCreate from './CartCreate/cart.create';
 import CountInfoPopUp from './CountInfoPopUp/countinfopopup';
 import B2bAddSubAccount from './B2bAddSubAccount/b2b.addsubaccount';
@@ -101,8 +99,10 @@ import CartClear from './CartClear/cartclear';
 import ProductDisplayItemDetails from './ProductDisplayItemDetails/productdisplayitem.details';
 import B2bSideMenu from './B2bSideMenu/b2b.sidemenu';
 
-const FacebookChat = lazy(() => import(/* webpackChunkName: "VRProductDisplayItem" */ './FacebookChat/facebookchat.main'));
-const ChatComponent = lazy(() => import(/* webpackChunkName: "VRProductDisplayItem" */ './ChatBot/chatbot'));
+const BulkOrderMain = lazy(() => import(/* webpackChunkName: "bulkorder" */ './BulkOrder/bulkorder.main'));
+const BarcodeScanner = lazy(() => import(/* webpackChunkName: "barcodescanner" */ './BarcodeScanner/barcodescanner'));
+const FacebookChat = lazy(() => import(/* webpackChunkName: "facebookchat" */ './FacebookChat/facebookchat.main'));
+const ChatComponent = lazy(() => import(/* webpackChunkName: "chatbot" */ './ChatBot/chatbot'));
 const VRProductDisplayItem = lazy(() => import(/* webpackChunkName: "VRProductDisplayItem" */ './VRProductDisplayItem/VRProductDisplayItem'));
 const B2BHomePage = lazy(() => import(/* webpackChunkName: "b2b.home.page" */ './B2bHomePage/b2b.home.page'));
 const B2CHomePage = lazy(() => import(/* webpackChunkName: "b2c.home.page" */ './B2cHomePage/b2c.home.page'));


### PR DESCRIPTION
Description:
<!--A brief description of changes. Things to include: WIP? Dependent PR's opened against other tickets? -->

https://elasticpath.atlassian.net/browse/RS-795

This PR makes it so that bulk order, barcode scanner and all its dependancies will not be pulled down when in B2C mode.

In B2B mode bulk order will be lazy loaded after hitting the web app for the first time.  Barcode scanner will be lazy loaded once the BulkOrder component is shown and opened from the header nav.

Our lighthouse score has increased by ~14 points and we are having initial pixel viewing times in ~4 seconds.

Here is a screenshot of performance from a netlify build in B2C mode:

![Screen Shot 2020-05-01 at 3 12 43 PM](https://user-images.githubusercontent.com/25829859/80834759-520fc100-8bbf-11ea-928c-68bb5278fc33.png)

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [ ] No linting errors

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
