### PR TITLE
Fix error with empty `ImageContainerSrcs.sizes` array

### DIFF
--- a/src/components/src/ImageContainer/image.container.tsx
+++ b/src/components/src/ImageContainer/image.container.tsx
@@ -78,7 +78,9 @@ const ImageContainer: React.FC<ImageContainerProps> = (props) => {
         {imageTypes.map(type => (
           <source
             key={`fileName${type}`}
-            srcSet={imageSizes.map(imageSize => `${imgPrefix.replace('%fileName%', `${type}/${fileName}-${imageSize}w.${type} ${imageSize}w`)}`).join(', ')}
+            srcSet={(imageSizes === undefined || imageSizes.length === 0)
+              ? `${imgPrefix.replace('%fileName%', `${type}/${fileName}.${type}`)}`
+              : imageSizes.map(imageSize => `${imgPrefix.replace('%fileName%', `${type}/${fileName}-${imageSize}w.${type} ${imageSize}w`)}`).join(', ')}
             type={`image/${type}`}
           />
         ))}


### PR DESCRIPTION
Description:
<!--A brief description of changes. Things to include: WIP? Dependent PR's opened against other tickets? -->

This PR fixes the case where no sizes are defined in the `ImageContainerSrcs.sizes`.  Picture element will now still work with just variance in types

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [ ] No linting errors

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [ ] Manual tests
- [ ] Accessibility tests (no new react-axe errors in console)

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
- [ ] Requires Storybook component updates
