### PR TITLE
[RS-867] Add the new S3 bucket name for the ref store

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "build-components": "cd src/components && yarn build",
     "test": "node scripts/test.js src/test",
     "lint": "eslint ./src/**/*.js --max-warnings=0 --format=codeframe",
-    "deploy": "aws s3 sync build/ s3://ref-store-new",
+    "deploy": "aws s3 sync build/ s3://epc-b2c-ref-exp",
     "storybook": "export NODE_OPTIONS=--max_old_space_size=2048 && cd storybook && start-storybook -p 9009 -s ./../public",
     "build-storybook": "cd storybook && build-storybook"
   },


### PR DESCRIPTION
Description:
- In package.json the deploy command updates the S3 bucket with
content of `./build` directory. This command was updated with the
new S3 bucket name.

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [ ] No linting errors

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [ ] Manual tests
- [ ] Accessibility tests (no new react-axe errors in console)

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
- [ ] Requires Storybook component updates
