### PR TITLE
Refactor productdisplayitem.details.tsx

### DIFF
--- a/src/components/src/ProductDisplayItemDetails/productdisplayitem.details.d.ts
+++ b/src/components/src/ProductDisplayItemDetails/productdisplayitem.details.d.ts
@@ -41,7 +41,6 @@ export interface ProductDisplayDetailsProps {
 }
 
 export interface ProductDisplayItemMainState {
-    requisitionListData: any,
     itemQuantity: number,
     itemConfiguration: { [key: string]: any },
     selectionValue: string,


### PR DESCRIPTION
Description:
This PR contains a set of major refactors to the `productdisplayitem.details.tsx` component which are intended to make it easier to reason about. They are geared towards making `ProductDisplayItemDetails` easier to reason about by breaking it up into sub-components, and replacing the extra `render*` functions with sub-components.

Notes:
- These changes were originally made branching off `v4.4.0`, so there may be additional changes required to bring it in-line with the current master
- I understand that this contains a huge set of changes, and this is likely to require additional discussion and changes before it's accepted. Please comment with your thoughts!

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests
- [ ] Accessibility tests (no new react-axe errors in console)

My manual testing consisted of verifying that the Product Display Page still displays as expected, and that the standard operations still function properly. I have not run E2E tests, as I have been unable to get them to pass running against `master`.

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
- [x] Requires Storybook component updates
