### PR TITLE
Top level category links have the correct route

### DIFF
--- a/src/components/src/AppHeaderNavigation/appheadernavigation.main.tsx
+++ b/src/components/src/AppHeaderNavigation/appheadernavigation.main.tsx
@@ -63,7 +63,7 @@ const SubMenu: React.FC<SubMenuProps> = (props) => {
           >
             <Link
               className={`nav__item-link nav__item-link--level-${level} ${(subCat.children && subCat.children.length > 0) ? 'nav__item-link--has-children' : ''}`}
-              to={`${level !== 0 ? '/category' : ''}/${subCat.name !== 'home' ? subCat.name : ''}`}
+              to={`/category/${subCat.name !== 'home' ? subCat.name : ''}`}
               onClick={e => props.onCategorySelected(e, prefix, subCat)}
               title={subCat.displayName}
             >


### PR DESCRIPTION
Description:
Now that categories are the only links in header, the check I removed allows the user to navigate to a top level category with no sub-categories rather than a blank page

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests I can now navigate to top level categories, and I have validated that you can navigate to the child categories as well
- [x] Accessibility tests (no new react-axe errors in console)

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
- [ ] Requires Storybook component updates
