### PR TITLE
Fix/quantity skuoption bug

### DIFF
--- a/src/components/src/ProductDisplayItemDetails/productdisplayitem.details.tsx
+++ b/src/components/src/ProductDisplayItemDetails/productdisplayitem.details.tsx
@@ -699,12 +699,11 @@ function ItemDetailSkuSelection({
     return null;
   }
 
-  productData._definition[0]._options[0]._element.map((ChoiceElement, index) => {
+  productData._definition[0]._options[0]._element.forEach((ChoiceElement, index) => {
     const selectorTitle = ChoiceElement['display-name'];
     const chosenItem = ChoiceElement._selector[0]._chosen[0];
-    const arraySelectors = ChoiceElement._selector[0]._choice || [];
+    const arraySelectors = [chosenItem, ...(ChoiceElement._selector[0]._choice || [])];
 
-    arraySelectors.unshift(chosenItem);
     if (selectorTitle === 'Size') {
       arraySelectors.sort((a, b) => {
         if (sizes.indexOf(a._description[0]['display-name']) < sizes.indexOf(b._description[0]['display-name'])) {
@@ -729,7 +728,6 @@ function ItemDetailSkuSelection({
     productKindsSelection.push(arraySelectors);
     productKindsSelection[index].displayName = selectorTitle;
     productKindsSelection[index].defaultChousen = chosenItem._description[0]['display-name'];
-    return productKindsSelection;
   });
 
   return (

--- a/src/components/src/ProductDisplayItemDetails/productdisplayitem.details.tsx
+++ b/src/components/src/ProductDisplayItemDetails/productdisplayitem.details.tsx
@@ -692,14 +692,13 @@ function ItemDetailSkuSelection({
   handleSelectionChange,
   handleSkuSelection,
 }) {
-  const productKindsSelection = [];
   const sizes = ['X-Small', 'Small', 'Medium', 'Large', 'X-Large'];
 
   if (!productData._definition[0]._options) {
     return null;
   }
 
-  productData._definition[0]._options[0]._element.forEach((ChoiceElement, index) => {
+  const productKindsSelection = productData._definition[0]._options[0]._element.map((ChoiceElement) => {
     const selectorTitle = ChoiceElement['display-name'];
     const chosenItem = ChoiceElement._selector[0]._chosen[0];
     const arraySelectors = [chosenItem, ...(ChoiceElement._selector[0]._choice || [])];
@@ -725,9 +724,12 @@ function ItemDetailSkuSelection({
         return 0;
       });
     }
-    productKindsSelection.push(arraySelectors);
-    productKindsSelection[index].displayName = selectorTitle;
-    productKindsSelection[index].defaultChousen = chosenItem._description[0]['display-name'];
+
+    return {
+      displayName: selectorTitle,
+      defaultChosen: chosenItem._description[0]['display-name'],
+      options: arraySelectors,
+    };
   });
 
   return (
@@ -741,7 +743,7 @@ function ItemDetailSkuSelection({
             {ComponentEl.displayName}
             :&nbsp;
             {(ComponentEl.displayName.includes('Color')) ? (
-              <span>{ComponentEl.defaultChousen}</span>
+              <span>{ComponentEl.defaultChosen}</span>
             ) : ''}
           </span>
           <div
@@ -749,12 +751,12 @@ function ItemDetailSkuSelection({
             id={`${(ComponentEl.displayName.includes('Color')) ? 'product_display_item_sku_guide' : 'product_display_item_size_guide'}${itemIndex || ''}`}
             onChange={handleSkuSelection}
           >
-            {ComponentEl.map(Element => (
+            {ComponentEl.options.map(Element => (
 
               <SkuSelectAxisOption
                 optionData={Element}
                 axisDisplayName={ComponentEl.displayName}
-                defaultChosen={ComponentEl.defaultChousen}
+                defaultChosen={ComponentEl.defaultChosen}
                 code={productData._code[0].code}
                 selectionValue={selectionValue}
               />


### PR DESCRIPTION
Description:

Fixes a bug on the product display page for multi-sku products. This bug was introduced in a [large refactor of productdisplayitem.details.tsx](https://github.com/elasticpath/react-pwa-reference-storefront/pull/766) which I submitted back in November. The nature of the bug is as follows:

On multi-sku product pages, when the quantity is adjusted, the currently-selected SKU option is duplicated. From what I can tell, this is due to modifying shared state. To resolve this, I have removed the shared state modification (`Array.prototype.unshift` was being called on a shared array) and instead created a new array using destructuring.

I have also added a small refactor commit, which replaces the combination of for-each loop pushing to an outside array (and then modifying that array using the current index) with a map function, which I believe is more intuitive and less error-prone.

Linting:
- [x] No linting errors

Tests:
- [ ] E2E tests (npm test run with `e2e`)
- [x] Manual tests
- [x] Accessibility tests (no new react-axe errors in console)

To verify the bug
1. Navigate to the product page for a multi-sku product
2. Update the item quantity in any way (typing, incrementing, decrementing)
3. Observe that the number of SKU options increases

To verify the fix
1. Repeat steps 1-2 of the previous test
2. Observe that the SKU options remain unchanged

Documentation:
- [ ] Requires documentation updates
- [ ] Requires Storybook component updates